### PR TITLE
Update baseline from Ubuntu 16.04 to 18.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 ENV HOST_CLANG_VER 12
 


### PR DESCRIPTION
Original was on master not on 13.0.1