### PR TITLE
Update to 15.0.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN apt update && \
     DEBIAN_FRONTEND=noninteractive eatmydata \
     apt build-dep -yy --arch-only qemu clang python
 
-ENV VER 15.0.0
+ENV VER 15.0.3
 ENV TOOLCHAIN_INSTALL /usr/local/clang+llvm-${VER}-cross-hexagon-unknown-linux-musl/
 ENV ROOT_INSTALL /usr/local/hexagon-unknown-linux-musl-rootfs
 ENV ARTIFACT_BASE /usr/local/hexagon-artifacts
@@ -68,12 +68,13 @@ ENV LINUX_SRC_URL https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.15.14.tar
 #ADD get-host-clang-cmake-python.sh /root/hexagon-toolchain/get-host-clang-cmake-python.sh
 #RUN cd /root/hexagon-toolchain && ./get-host-clang-cmake-python.sh
 
+ADD test-suite-patches /root/hexagon-toolchain/test-suite-patches
 ADD get-src-tarballs.sh /root/hexagon-toolchain/get-src-tarballs.sh
 RUN cd /root/hexagon-toolchain && ./get-src-tarballs.sh ${PWD} ${TOOLCHAIN_INSTALL}/manifest
 
 ARG ARTIFACT_TAG=${VER}
 ADD build-toolchain.sh /root/hexagon-toolchain/build-toolchain.sh
-RUN cd /root/hexagon-toolchain && ./build-toolchain.sh 15.0.0
+RUN cd /root/hexagon-toolchain && ./build-toolchain.sh ${ARTIFACT_TAG}
 
 ARG TEST_TOOLCHAIN=1
 

--- a/get-src-tarballs.sh
+++ b/get-src-tarballs.sh
@@ -21,6 +21,7 @@ get_src_tarballs() {
 	mkdir qemu
 	cd qemu
 	tar xf ../qemu.tar.xz --strip-components=1
+	patch -p1 < ../test-suite-patches/0002-remove-unused-variable.patch
 	rm ../qemu.tar.xz
 	echo ${QEMU_SRC_URL} > ${MANIFEST_DIR}/qemu.txt
 	cd -

--- a/test-suite-patches/0002-remove-unused-variable.patch
+++ b/test-suite-patches/0002-remove-unused-variable.patch
@@ -1,0 +1,24 @@
+--- qemu/tests/tcg/multiarch/linux/linux-test.c.old	2022-11-07 15:33:05.862410841 +0530
++++ qemu/tests/tcg/multiarch/linux/linux-test.c	2022-11-07 15:33:38.982404440 +0530
+@@ -332,12 +332,11 @@
+     fd_set rfds, wfds;
+     int fds[2], fd_max, ret;
+     uint8_t ch;
+-    int wcount, rcount;
++    int rcount;
+ 
+     chk_error(pipe(fds));
+     chk_error(fcntl(fds[0], F_SETFL, O_NONBLOCK));
+     chk_error(fcntl(fds[1], F_SETFL, O_NONBLOCK));
+-    wcount = 0;
+     rcount = 0;
+     for(;;) {
+         FD_ZERO(&rfds);
+@@ -360,7 +359,6 @@
+             if (FD_ISSET(fds[1], &wfds)) {
+                 ch = 'a';
+                 chk_error(write(fds[1], &ch, 1));
+-                wcount++;
+             }
+         }
+     }


### PR DESCRIPTION
This commit includes a patch to the QEMU test suite. The tcg/multiarch/linux/linux-test.c file fails to compile under -Wall with LLVM 15.0.3

This is likely due to [recent improvements][1] to the -Wno-unused-but-set-variable diagnostic to fix false negatives when post/pre increment/decrement operator are involved.

The patch simply deletes the unused variable since the semantics of the test will remain the same.

[1]: https://github.com/llvm/llvm-project/issues/54595#issuecomment-1081022049