### PR TITLE
Use python3.8 with QEMU configure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN apt update && \
         wget \
 	build-essential \
 	python3.6 \
+	python3.8 \
 	curl \
 	xz-utils \
 	ca-certificates \

--- a/build-toolchain.sh
+++ b/build-toolchain.sh
@@ -209,7 +209,7 @@ build_qemu() {
 	CC=$(which gcc) \
 	../qemu/configure --disable-fdt --disable-capstone --disable-guest-agent \
 	                  --disable-containers \
-	                  --python=$(which python3.6) \
+	                  --python=$(which python3.8) \
 		--target-list=hexagon-linux-user --prefix=${TOOLCHAIN_INSTALL}/x86_64-linux-gnu \
 
 #	--cc=clang \


### PR DESCRIPTION
QEMU no longer supports python3.6, giving the following error when we run build-toolchain.sh:

ERROR: Cannot use '/usr/bin/python3.6', Python >= 3.7 is required.
       Use --python=/path/to/python to specify a supported Python.

So let's update to python3.8.