### PR TITLE
Add new clang aliases that omit the {vendor}

### DIFF
--- a/build-toolchain.sh
+++ b/build-toolchain.sh
@@ -84,11 +84,15 @@ add_symlinks() {
 
 	for triple in hexagon-unknown-linux-musl hexagon-unknown-none-elf
 	do
+		ln -sf --relative ${linkdir}/llvm-size ${linkdir}/${triple}-size
+		ln -sf --relative ${linkdir}/llvm-strip ${linkdir}/${triple}-strip
+		ln -sf --relative ${linkdir}/llvm-nm ${linkdir}/${triple}-nm
 		ln -sf --relative ${linkdir}/llvm-ar ${linkdir}/${triple}-ar
 		ln -sf --relative ${linkdir}/llvm-objdump ${linkdir}/${triple}-objdump
 		ln -sf --relative ${linkdir}/llvm-objcopy ${linkdir}/${triple}-objcopy
 		ln -sf --relative ${linkdir}/llvm-readelf ${linkdir}/${triple}-readelf
 		ln -sf --relative ${linkdir}/llvm-ranlib ${linkdir}/${triple}-ranlib
+		ln -sf --relative ${linkdir}/llvm-config ${linkdir}/${triple}-llvm-config
 	done
 
 #	ln -sf --relative ${linkdir}/clang ${linkdir}/hexagon-unknown-none-elf-clang

--- a/build-toolchain.sh
+++ b/build-toolchain.sh
@@ -82,7 +82,7 @@ build_llvm_clang() {
 add_symlinks() {
     linkdir=${1}
 
-	for triple in hexagon-unknown-linux-musl hexagon-unknown-none-elf
+	for triple in hexagon-unknown-linux-musl hexagon-unknown-none-elf hexagon-linux-musl hexagon-none-elf
 	do
 		ln -sf --relative ${linkdir}/llvm-size ${linkdir}/${triple}-size
 		ln -sf --relative ${linkdir}/llvm-strip ${linkdir}/${triple}-strip
@@ -167,6 +167,7 @@ build_musl_headers() {
 
 	cd ${HEX_SYSROOT}/..
 	ln -sf hexagon-unknown-linux-musl hexagon
+	ln -sf hexagon-unknown-linux-musl hexagon-linux-musl
 }
 
 build_musl() {

--- a/hexagon-unknown-linux-musl-clang-cross.cmake
+++ b/hexagon-unknown-linux-musl-clang-cross.cmake
@@ -2,8 +2,12 @@
 # a cross-toolchain targeting hexagon linux.
 set(DEFAULT_SYSROOT "../target/hexagon-unknown-linux-musl/" CACHE STRING "")
 set(CLANG_LINKS_TO_CREATE
+            hexagon-linux-musl-clang++
+            hexagon-linux-musl-clang
             hexagon-unknown-linux-musl-clang++
             hexagon-unknown-linux-musl-clang
+            hexagon-none-elf-clang++
+            hexagon-none-elf-clang
             hexagon-unknown-none-elf-clang++
             hexagon-unknown-none-elf-clang
             CACHE STRING "")


### PR DESCRIPTION
The vendor is implicitly "unknown", so it's safe to omit and should be unambiguous when omitted.

Suggested-by: Sid Manning <sidneym@quicinc.com>