### PR TITLE
Clarify how to setup for dev use

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ Or instead you can check out the trunk of those projects' repos using
 
 Once the source repos are setup, build the toolchain using `build-toolchain.sh`.
 
+> [!IMPORTANT]
+> Note that build-toolchain.sh often makes assumptions about the source repos such
+> that you should only expect it to work if you check out the known-good git refs
+> used for previous releases.
+
 `build-toolchain.sh` / `build-buildroot.sh` expect the inputs below as environment
 variables:
 

--- a/get-src-repos.sh
+++ b/get-src-repos.sh
@@ -41,3 +41,8 @@ dump_checkout_info() {
 
 mkdir -p ${MANIFEST_DIR}
 dump_checkout_info ${MANIFEST_DIR}
+
+cat <<EOF
+Now that you've cloned the source repos, refer to Dockerfile to find the git refs
+of each repo that should be checked out to build a known good configuration.
+EOF


### PR DESCRIPTION
When starting out, it's not obvious how to setup the development environment to rebuild the toolchain outside of docker.