### PR TITLE
Update musl tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN apt update && \
 	unzip && \
     update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${HOST_CLANG_VER} 100 && \
     update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${HOST_CLANG_VER} 100 && \
+    DEBIAN_FRONTEND=noninteractive eatmydata apt install -y --no-install-recommends llvm-${HOST_CLANG_VER} && \
     update-alternatives --install /usr/bin/python python /usr/bin/python3 100
 
 # Install Python packages that are not available in Ubuntu repos

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ ENV MAKE_TARBALLS 1
 ENV LLVM_SRC_URL https://github.com/llvm/llvm-project/archive/llvmorg-${VER}.tar.gz
 ENV ELD_SRC_URL https://github.com/qualcomm/eld/archive/refs/tags/eld_04_16_2025.tar.gz
 ENV LLVM_TESTS_SRC_URL https://github.com/llvm/llvm-test-suite/archive/llvmorg-${VER}.tar.gz
-ENV MUSL_SRC_URL https://github.com/quic/musl/archive/hexagon-mar1-2025.tar.gz
+ENV MUSL_SRC_URL https://github.com/quic/musl/archive/hexagon-v1.2.4-dec-2025.tar.gz
 ENV LINUX_SRC_URL https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.13.5.tar.xz
 ENV BUSYBOX_SRC_URL https://busybox.net/downloads/busybox-1.36.1.tar.bz2
 ENV BUILDROOT_SRC_URL https://github.com/quic/buildroot/archive/hexagon-2025.04.30.tar.gz

--- a/get-src-repos.sh
+++ b/get-src-repos.sh
@@ -18,7 +18,7 @@ git clone -q https://git.busybox.net/busybox/ &
 git clone -q https://github.com/quic/buildroot/ &
 
 
-git clone -q --branch=hexagon https://github.com/quic/musl &
+git clone -q --branch=hexagon-v1.2.4-dec-2025 https://github.com/quic/musl &
 git clone -q https://github.com/quic/hexagonMVM &
 git clone -q https://github.com/qemu/qemu &
 


### PR DESCRIPTION
Among other things, this musl tag contains the commit: "hexagon sigcontext: fix alignment at mcontext_t struct (#8)".

Also add missing llvm-14 to Dockerfile, needed for toolchain build.
