### PR TITLE
Add picolibc baremetal support for hexagon-unknown-none-elf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN apt update && \
     update-alternatives --install /usr/bin/python python /usr/bin/python3 100
 
 # Install Python packages that are not available in Ubuntu repos
-RUN python3 -m pip install tomli tomli-w
+RUN python3 -m pip install tomli tomli-w meson
 
 RUN cat /etc/apt/sources.list | sed "s/^deb\ /deb-src /" >> /etc/apt/sources.list
 
@@ -73,6 +73,7 @@ ENV LLVM_TESTS_SRC_URL https://github.com/llvm/llvm-test-suite/archive/llvmorg-$
 ENV MUSL_SRC_URL https://github.com/quic/musl/archive/hexagon-v1.2.4-dec-2025.tar.gz
 ENV LINUX_SRC_URL https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.13.5.tar.xz
 ENV BUSYBOX_SRC_URL https://busybox.net/downloads/busybox-1.36.1.tar.bz2
+ENV PICOLIBC_SRC_URL https://github.com/picolibc/picolibc/releases/download/1.8.11/picolibc-1.8.11.tar.xz
 ENV BUILDROOT_SRC_URL https://github.com/quic/buildroot/archive/hexagon-2025.04.30.tar.gz
 
 ADD test-suite-patches /root/hexagon-toolchain/test-suite-patches

--- a/get-src-tarballs.sh
+++ b/get-src-tarballs.sh
@@ -60,6 +60,14 @@ get_src_tarballs() {
 	tar xf ../linux.tar.xz --strip-components=1
 	echo ${LINUX_SRC_URL} > ${MANIFEST_DIR}/linux.txt
 	cd -
+
+	wget --quiet ${PICOLIBC_SRC_URL} -O picolibc.tar.xz
+	mkdir picolibc
+	cd picolibc
+	tar xf ../picolibc.tar.xz --strip-components=1
+	rm ../picolibc.tar.xz
+	echo ${PICOLIBC_SRC_URL} > ${MANIFEST_DIR}/picolibc.txt
+	cd -
 }
 
 SRC_DIR=${1}


### PR DESCRIPTION
Build and install picolibc as the C library for baremetal hexagon targets, alongside the existing musl-based linux target support.

The picolibc sysroot is installed into a separate tree at target/picolibc/hexagon-unknown-none-elf/ so it does not interfere with the linux/musl sysroot.