### PR TITLE
Fix missing libclang-cpp.so in dylib cross-build tarballs

### DIFF
--- a/build-toolchain.sh
+++ b/build-toolchain.sh
@@ -42,7 +42,7 @@ build_llvm_clang_cross() {
 	DYLIB=""
 	if [[ "${dylib}" == "ON" ]]; then
 		DYLIB="-C ./cmake/caches/hexagon-stage0-dylib.cmake"
-		DIST_COMPONENTS+=(LLVM)
+		DIST_COMPONENTS+=(LLVM clang-cpp)
 	fi
 	DIST_LIST=$(IFS=';'; echo "${DIST_COMPONENTS[*]}")
 


### PR DESCRIPTION
The x86_64-linux-musl and aarch64-linux-musl cross-builds use hexagon-stage0-dylib.cmake which enables CLANG_LINK_LLVM_DYLIB, causing the clang binary to dynamically link against libclang-cpp.so. However, only the LLVM distribution component (libLLVM.so) was listed in DIST_COMPONENTS — the clang-cpp component (libclang-cpp.so) was missing, so install-distribution never installed it into the tarball.

Add clang-cpp to the distribution components for dylib builds so that the resulting tarballs include all required shared libraries.

Fixes: https://github.com/quic/toolchain_for_hexagon/issues/60