### PR TITLE
Add Zig QuRT + QHL example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -53,6 +53,14 @@ under `qemu-hexagon`.
 | [ubsan/](ubsan/) | Undefined Behavior Sanitizer | Signed overflow, bad shift, null deref |
 | [asan/](asan/) | Address Sanitizer | Heap overflow, use-after-free, stack overflow |
 
+### QuRT (Qualcomm Real-Time OS)
+
+These programs target QuRT RTOS and require the [Hexagon SDK](https://developer.qualcomm.com/software/hexagon-dsp-sdk).
+
+| Example | Description |
+|---------|-------------|
+| [zig-qurt-qhl/](zig-qurt-qhl/) | Zig + QuRT with QHL including HVX-accelerated math, BLAS, and DSP |
+
 ### Other
 
 | Example | Description |

--- a/examples/zig-qurt-qhl/.gitignore
+++ b/examples/zig-qurt-qhl/.gitignore
@@ -1,0 +1,15 @@
+# Zig build artifacts
+zig-out/
+zig-cache/
+.zig-cache/
+
+# Editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/examples/zig-qurt-qhl/Makefile
+++ b/examples/zig-qurt-qhl/Makefile
@@ -1,0 +1,66 @@
+# Makefile for Zig QuRT QHL example
+#
+# Prerequisites:
+#   1. Source the Hexagon SDK environment:
+#      source /opt/Hexagon_SDK/6.4.0.2/setup_sdk_env.source
+#   2. Have Zig installed (0.11.0 or newer)
+
+.PHONY: all build run clean help
+
+# Default target
+all: build
+
+# Build the example
+build:
+	@echo "Building Zig QuRT QHL example..."
+	@if [ -z "$$HEXAGON_SDK_ROOT" ]; then \
+		echo "Error: HEXAGON_SDK_ROOT is not set."; \
+		echo "Please run: source /opt/Hexagon_SDK/6.4.0.2/setup_sdk_env.source"; \
+		exit 1; \
+	fi
+	zig build
+
+# Build with specific architecture
+build-v73:
+	zig build -Darch=v73
+
+build-v75:
+	zig build -Darch=v75
+
+build-v68:
+	zig build -Darch=v68
+
+# Build optimized
+build-release:
+	zig build -Doptimize=ReleaseFast
+
+# Run the example on QEMU
+run:
+	@echo "Running on QEMU..."
+	@if [ -z "$$HEXAGON_SDK_ROOT" ]; then \
+		echo "Error: HEXAGON_SDK_ROOT is not set."; \
+		echo "Please run: source /opt/Hexagon_SDK/6.4.0.2/setup_sdk_env.source"; \
+		exit 1; \
+	fi
+	zig build run
+
+# Clean build artifacts
+clean:
+	rm -rf zig-out zig-cache .zig-cache
+
+# Show help
+help:
+	@echo "Zig QuRT QHL Example - Build targets:"
+	@echo ""
+	@echo "  make              - Build the example (default)"
+	@echo "  make build        - Build the example"
+	@echo "  make build-v73    - Build for Hexagon v73"
+	@echo "  make build-v75    - Build for Hexagon v75"
+	@echo "  make build-v68    - Build for Hexagon v68"
+	@echo "  make build-release - Build with optimizations"
+	@echo "  make run          - Build and run on QEMU"
+	@echo "  make clean        - Remove build artifacts"
+	@echo "  make help         - Show this help"
+	@echo ""
+	@echo "Prerequisites:"
+	@echo "  source /opt/Hexagon_SDK/6.4.0.2/setup_sdk_env.source"

--- a/examples/zig-qurt-qhl/README.md
+++ b/examples/zig-qurt-qhl/README.md
@@ -1,0 +1,89 @@
+# Zig QuRT with QHL Libraries Example
+
+This example demonstrates how to use **pure Zig to build programs targeting Qualcomm's QuRT RTOS**.
+
+## Prerequisites
+
+1. **Hexagon SDK**: Install the Hexagon SDK (version 6.4.0.2 or compatible)
+   - Download from [Qualcomm Hexagon SDK](https://developer.qualcomm.com/software/hexagon-dsp-sdk)
+   - Default installation path: `/opt/Hexagon_SDK/6.4.0.2`
+
+2. **Zig**: Install Zig (0.11.0 or newer recommended)
+   - Download from [ziglang.org](https://ziglang.org/download/)
+
+3. **Set up the SDK environment**:
+   ```bash
+   source /opt/Hexagon_SDK/6.4.0.2/setup_sdk_env.source
+   ```
+
+## Building
+
+Build the example:
+
+```bash
+zig build
+```
+
+Build with specific options:
+
+```bash
+# Build for different Hexagon architecture versions
+zig build -Darch=v75  # Default
+zig build -Darch=v73
+zig build -Darch=v68
+
+# Build with optimization
+zig build -Doptimize=ReleaseFast
+```
+
+## Running
+
+Execute with QEMU:
+
+```bash
+zig build run
+```
+
+Or manually with the Hexagon SDK's QEMU:
+
+```bash
+/opt/Hexagon_SDK/6.4.0.2/tools/Tools/QEMUHexagon/bin/qemu-system-hexagon \
+    -kernel /opt/Hexagon_SDK/6.4.0.2/rtos/qurt/computev75/sdksim_bin/runelf.pbn \
+    -append '/opt/Hexagon_SDK/6.4.0.2/libs/run_main_on_hexagon/ship/hexagon_toolv19_v75/run_main_on_hexagon_sim -- zig-out/build/libqurt-qhl-demo.so'
+```
+## Linker Considerations
+
+This example uses the Hexagon SDK's linker (`ld.qcld`) via hexagon-clang for QuRT shared libraries.
+
+To use **ld.lld** instead, uncomment the lld flags in `build.zig`. The following flags are needed:
+
+```
+-fuse-ld=lld
+-Wl,-z,max-page-size=4096
+-Wl,-z,common-page-size=4096
+-Wl,-z,separate-loadable-segments
+```
+
+- **Page size flags**: QuRT uses 4K pages. Without these, lld may produce segments with larger alignment that QuRT's loader cannot handle.
+- **Separate loadable segments**: Prevents lld from merging adjacent PT_LOAD segments. QuRT's dynamic loader expects each segment to be distinct.
+
+## Environment Variables
+
+The build.zig reads these environment variables (set by `setup_sdk_env.source`):
+
+- `HEXAGON_SDK_ROOT`: Path to the Hexagon SDK installation
+- `HEXAGON_TOOLS_ROOT`: Path to the Hexagon tools
+- `V_ARCH`: Target Hexagon architecture version (e.g., v75, v73)
+
+
+## QuRT Runtime Libraries
+
+The example links against the QuRT runtime:
+- `${HEXAGON_SDK_ROOT}/rtos/qurt/compute${V_ARCH}/lib/`
+- System includes: `${HEXAGON_SDK_ROOT}/rtos/qurt/compute${V_ARCH}/include/`
+
+## References
+
+- [Hexagon SDK Documentation](https://developer.qualcomm.com/software/hexagon-dsp-sdk)
+- [QHL API Documentation](https://developer.qualcomm.com/qfile/69578/qhl_api_reference.pdf)
+- [Zig Build System](https://ziglang.org/documentation/master/#Build-System)

--- a/examples/zig-qurt-qhl/build.zig
+++ b/examples/zig-qurt-qhl/build.zig
@@ -1,0 +1,183 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) !void {
+    // Read environment variables from Hexagon SDK setup
+    const hexagon_sdk_root = b.graph.environ_map.get("HEXAGON_SDK_ROOT") orelse "/opt/Hexagon_SDK/6.4.0.2";
+
+    // Architecture version (v68, v69, v73, v75, v79, v81)
+    const arch_option = b.option([]const u8, "arch", "Hexagon architecture version (v68, v73, v75, etc.)") orelse "v75";
+
+    // Determine toolchain version
+    const tool_version = "hexagon_toolv19";
+
+    // Paths
+    const hexagon_tools = try std.fmt.allocPrint(
+        b.allocator,
+        "{s}/tools/HEXAGON_Tools/19.0.04/Tools",
+        .{hexagon_sdk_root},
+    );
+
+    const qurt_dir = try std.fmt.allocPrint(
+        b.allocator,
+        "{s}/rtos/qurt/compute{s}",
+        .{ hexagon_sdk_root, arch_option },
+    );
+
+    const qhl_hvx_dir = try std.fmt.allocPrint(
+        b.allocator,
+        "{s}/libs/qhl_hvx/prebuilt/{s}_{s}",
+        .{ hexagon_sdk_root, tool_version, arch_option },
+    );
+
+    const qhl_dir = try std.fmt.allocPrint(
+        b.allocator,
+        "{s}/libs/qhl/prebuilt/{s}_{s}",
+        .{ hexagon_sdk_root, tool_version, arch_option },
+    );
+
+    // Output directory
+    const build_dir = "zig-out/build";
+    const main_obj = try std.fmt.allocPrint(b.allocator, "{s}/main.o", .{build_dir});
+    const output_so = try std.fmt.allocPrint(
+        b.allocator,
+        "{s}/libqurt-qhl-demo.so",
+        .{build_dir},
+    );
+
+    // hexagon-clang path
+    const hexagon_clang = try std.fmt.allocPrint(
+        b.allocator,
+        "{s}/bin/hexagon-clang",
+        .{hexagon_tools},
+    );
+
+    // Architecture flags
+    const arch_flag = try std.fmt.allocPrint(b.allocator, "-m{s}", .{arch_option});
+
+    // Create build directory
+    const mkdir_cmd = b.addSystemCommand(&[_][]const u8{
+        "mkdir",
+        "-p",
+        build_dir,
+    });
+
+    // Step 1: Compile Zig source to object file
+    const zig_compile = b.addSystemCommand(&[_][]const u8{
+        "zig",
+        "build-obj",
+        "src/main.zig",
+        "-target",
+        "hexagon-freestanding-none",
+        "-mcpu",
+        try std.fmt.allocPrint(b.allocator, "hexagon{s}+hvx+hvx{s}+hvx_length128b", .{ arch_option, arch_option }),
+        "-fPIC",
+        "-O",
+        "ReleaseFast",
+        try std.fmt.allocPrint(b.allocator, "-femit-bin={s}", .{main_obj}),
+    });
+
+    zig_compile.step.dependOn(&mkdir_cmd.step);
+
+    // Step 2: Link everything using hexagon-clang (which uses ld.qcld)
+    const compile_cmd = b.addSystemCommand(&[_][]const u8{
+        hexagon_clang,
+        // Uncomment the following to use ld.lld instead of ld.qcld:
+        // "-fuse-ld=lld",
+        // "-Wl,-z,max-page-size=4096",   // QuRT uses 4K pages
+        // "-Wl,-z,common-page-size=4096",
+        // "-Wl,-z,separate-loadable-segments", // keep PT_LOAD segments distinct for QuRT
+        arch_flag,
+        "-G0",
+        "-mhvx",
+        "-mhvx-length=128B",
+        "-fno-zero-initialized-in-bss",
+        "-fdata-sections",
+        "-fpic",
+        "-shared",
+        "-o",
+        output_so,
+        main_obj,
+    });
+
+    // Add include paths
+    compile_cmd.addArgs(&[_][]const u8{
+        "-I",
+        try std.fmt.allocPrint(b.allocator, "{s}/include", .{qurt_dir}),
+        "-I",
+        try std.fmt.allocPrint(b.allocator, "{s}/include/qurt", .{qurt_dir}),
+        "-I",
+        try std.fmt.allocPrint(b.allocator, "{s}/include/posix", .{qurt_dir}),
+        "-I",
+        try std.fmt.allocPrint(b.allocator, "{s}/incs", .{hexagon_sdk_root}),
+        "-I",
+        try std.fmt.allocPrint(b.allocator, "{s}/incs/stddef", .{hexagon_sdk_root}),
+        "-I",
+        try std.fmt.allocPrint(b.allocator, "{s}/libs/qhl_hvx/inc", .{hexagon_sdk_root}),
+        "-I",
+        try std.fmt.allocPrint(b.allocator, "{s}/libs/qhl/inc", .{hexagon_sdk_root}),
+        "-I",
+        try std.fmt.allocPrint(b.allocator, "{s}/libs/qhl/inc/qhcomplex", .{hexagon_sdk_root}),
+    });
+
+    // Add library paths and libraries
+    compile_cmd.addArgs(&[_][]const u8{
+        "-L",
+        qhl_hvx_dir,
+        "-L",
+        qhl_dir,
+        "-L",
+        try std.fmt.allocPrint(b.allocator, "{s}/lib", .{qurt_dir}),
+        try std.fmt.allocPrint(b.allocator, "{s}/libqhmath_hvx.a", .{qhl_hvx_dir}),
+        try std.fmt.allocPrint(b.allocator, "{s}/libqhblas_hvx.a", .{qhl_hvx_dir}),
+        try std.fmt.allocPrint(b.allocator, "{s}/libqhdsp_hvx.a", .{qhl_hvx_dir}),
+        try std.fmt.allocPrint(b.allocator, "{s}/libqhcomplex.a", .{qhl_dir}),
+        try std.fmt.allocPrint(b.allocator, "{s}/libqhmath.a", .{qhl_dir}),
+        "-lc",
+        "-lgcc",
+    });
+
+    compile_cmd.step.dependOn(&zig_compile.step);
+
+    // Add to default install step
+    b.default_step.dependOn(&compile_cmd.step);
+
+    // Run step for QEMU execution
+    const run_main_on_hexagon = try std.fmt.allocPrint(
+        b.allocator,
+        "{s}/libs/run_main_on_hexagon/ship/{s}_{s}/run_main_on_hexagon_sim",
+        .{ hexagon_sdk_root, tool_version, arch_option },
+    );
+
+    const runelf_path = try std.fmt.allocPrint(
+        b.allocator,
+        "{s}/sdksim_bin/runelf.pbn",
+        .{qurt_dir},
+    );
+
+    const qemu_path = try std.fmt.allocPrint(
+        b.allocator,
+        "{s}/tools/Tools/QEMUHexagon/bin/qemu-system-hexagon",
+        .{hexagon_sdk_root},
+    );
+
+    const run_cmd = b.addSystemCommand(&[_][]const u8{
+        qemu_path,
+        "-kernel",
+        runelf_path,
+        "-append",
+    });
+
+    // Get absolute path to the output .so file for QEMU to access
+    const absolute_so_path = try b.build_root.join(b.allocator, &[_][]const u8{output_so});
+
+    const append_arg = try std.fmt.allocPrint(
+        b.allocator,
+        "{s} -- {s}",
+        .{ run_main_on_hexagon, absolute_so_path },
+    );
+    run_cmd.addArg(append_arg);
+    run_cmd.step.dependOn(&compile_cmd.step);
+
+    const run_step = b.step("run", "Run the QuRT demo on QEMU");
+    run_step.dependOn(&run_cmd.step);
+}

--- a/examples/zig-qurt-qhl/src/main.zig
+++ b/examples/zig-qurt-qhl/src/main.zig
@@ -1,0 +1,295 @@
+const std = @import("std");
+
+// External C functions - no need for @cImport, just declare them
+extern fn printf(format: [*:0]const u8, ...) c_int;
+
+// Helper function for floating-point comparison with tolerance
+fn approxEqual(a: f32, b: f32, tolerance: f32) bool {
+    return @abs(a - b) <= tolerance;
+}
+
+// QHL Math HVX functions
+extern fn qhmath_hvx_sqrt_af(input: [*]f32, output: [*]f32, size: u32) i32;
+extern fn qhmath_hvx_sin_af(input: [*]f32, output: [*]f32, size: u32) i32;
+extern fn qhmath_hvx_exp_af(input: [*]f32, output: [*]f32, size: u32) i32;
+
+// QHL BLAS HVX functions
+extern fn qhblas_hvx_w_vector_dot_ah(input_1: [*]i16, input_2: [*]i16, output: *i32, size: u32) i32;
+
+// QHL DSP HVX functions
+extern fn qhdsp_hvx_bkfir_af(input: [*]f32, coef: [*]f32, output: [*]f32, length: u32, taps: u32) i32;
+extern fn qhdsp_hvx_r1dfft_af(input: [*]f32, N: u32, output: [*]f32, twiddles: [*]f32) i32;
+
+// QHL Complex functions (C99 complex.h compatible)
+// These use complex structures, not separate real/imag
+const float_complex = extern struct {
+    real: f32,
+    imag: f32,
+};
+extern fn qhcomplex_cabs_f(z: float_complex) f32;
+extern fn qhcomplex_carg_f(z: float_complex) f32;
+extern fn qhcomplex_conj_f(z: float_complex) float_complex;
+
+const ARRAY_SIZE = 16;
+const MATRIX_SIZE = 4;
+
+// Demonstrate QHL Math HVX functions
+export fn qhl_math_demo() void {
+    var input: [ARRAY_SIZE]f32 align(128) = undefined;
+    var output: [ARRAY_SIZE]f32 align(128) = undefined;
+
+    _ = printf("  QHL Math HVX Demo:\n");
+
+    // Initialize test data
+    for (0..ARRAY_SIZE) |i| {
+        input[i] = @as(f32, @floatFromInt(i + 1)) * 0.5;
+    }
+
+    // Test qhmath_hvx_sqrt_af - HVX-accelerated square root
+    var ret = qhmath_hvx_sqrt_af(&input, &output, ARRAY_SIZE);
+    if (ret == 0) {
+        _ = printf("    sqrt_f results:\n");
+        _ = printf("      Input:  [%.2f, %.2f, %.2f, %.2f, ...]\n",
+            input[0], input[1], input[2], input[3]);
+        _ = printf("      Output: [%.4f, %.4f, %.4f, %.4f, ...]\n",
+            output[0], output[1], output[2], output[3]);
+
+        // Verify results: sqrt(0.5) ~= 0.707, sqrt(1.0) = 1.0, sqrt(4.0) = 2.0
+        std.debug.assert(approxEqual(output[0], 0.7071, 0.001));
+        std.debug.assert(approxEqual(output[1], 1.0000, 0.001));
+        std.debug.assert(approxEqual(output[7], 2.0000, 0.001));
+        _ = printf("      [OK] Assertions passed\n");
+    } else {
+        _ = printf("    sqrt_f failed with error: %d\n", ret);
+    }
+
+    // Test qhmath_hvx_sin_af - HVX-accelerated sine
+    for (0..ARRAY_SIZE) |i| {
+        input[i] = @as(f32, @floatFromInt(i)) * 0.1;
+    }
+
+    ret = qhmath_hvx_sin_af(&input, &output, ARRAY_SIZE);
+    if (ret == 0) {
+        _ = printf("    sin_f results:\n");
+        _ = printf("      Input:  [%.2f, %.2f, %.2f, %.2f, ...]\n",
+            input[0], input[1], input[2], input[3]);
+        _ = printf("      Output: [%.4f, %.4f, %.4f, %.4f, ...]\n",
+            output[0], output[1], output[2], output[3]);
+
+        // Verify results: sin(0) = 0, sin(0.1) ~= 0.0998
+        std.debug.assert(approxEqual(output[0], 0.0, 0.001));
+        std.debug.assert(approxEqual(output[1], 0.0998, 0.001));
+        _ = printf("      [OK] Assertions passed\n");
+    } else {
+        _ = printf("    sin_f failed with error: %d\n", ret);
+    }
+
+    // Test qhmath_hvx_exp_af - HVX-accelerated exponential
+    for (0..ARRAY_SIZE) |i| {
+        input[i] = @as(f32, @floatFromInt(i)) * 0.2;
+    }
+
+    ret = qhmath_hvx_exp_af(&input, &output, ARRAY_SIZE);
+    if (ret == 0) {
+        _ = printf("    exp_f results:\n");
+        _ = printf("      Input:  [%.2f, %.2f, %.2f, %.2f, ...]\n",
+            input[0], input[1], input[2], input[3]);
+        _ = printf("      Output: [%.4f, %.4f, %.4f, %.4f, ...]\n",
+            output[0], output[1], output[2], output[3]);
+
+        // Verify results: exp(0) = 1.0, exp(0.2) ~= 1.2214
+        std.debug.assert(approxEqual(output[0], 1.0000, 0.001));
+        std.debug.assert(approxEqual(output[1], 1.2214, 0.001));
+        _ = printf("      [OK] Assertions passed\n");
+    } else {
+        _ = printf("    exp_f failed with error: %d\n", ret);
+    }
+}
+
+// Demonstrate QHL BLAS HVX functions
+export fn qhl_blas_demo() void {
+    var vector_a: [MATRIX_SIZE]i16 align(128) = undefined;
+    var vector_b: [MATRIX_SIZE]i16 align(128) = undefined;
+
+    _ = printf("  QHL BLAS HVX Demo:\n");
+
+    // Initialize 16-bit fixed-point vectors
+    for (0..MATRIX_SIZE) |i| {
+        vector_a[i] = @as(i16, @intCast(i + 1));
+        vector_b[i] = @as(i16, @intCast((i + 1) * 2));
+    }
+
+    _ = printf("      Vector A (int16): [%d, %d, %d, %d]\n",
+        vector_a[0], vector_a[1], vector_a[2], vector_a[3]);
+    _ = printf("      Vector B (int16): [%d, %d, %d, %d]\n",
+        vector_b[0], vector_b[1], vector_b[2], vector_b[3]);
+
+    // Test qhblas_hvx_w_vector_dot_ah - 16-bit dot product
+    var dot_result: i32 = 0;
+    const ret = qhblas_hvx_w_vector_dot_ah(&vector_a, &vector_b, &dot_result, MATRIX_SIZE);
+    if (ret == 0) {
+        _ = printf("    Dot product result (HVX raw): %ld\n", @as(c_long, dot_result));
+        _ = printf("    Dot product result (scaled): %ld\n", @as(c_long, dot_result >> 1));
+
+        // Calculate reference result for comparison
+        var ref_result: i32 = 0;
+        for (0..MATRIX_SIZE) |i| {
+            ref_result += @as(i32, vector_a[i]) * @as(i32, vector_b[i]);
+        }
+        _ = printf("    Dot product result (reference): %ld\n", @as(c_long, ref_result));
+        _ = printf("      Expected: (1*2 + 2*4 + 3*6 + 4*8) = 60\n");
+        _ = printf("      Note: HVX int16 dot product returns result << 1\n");
+
+        // Verify: HVX returns result << 1, so 60 * 2 = 120
+        std.debug.assert(dot_result == 120);
+        std.debug.assert((dot_result >> 1) == ref_result);
+        std.debug.assert(ref_result == 60);
+        _ = printf("      [OK] Assertions passed\n");
+    } else {
+        _ = printf("    Dot product failed with error: %d\n", ret);
+    }
+}
+
+// Demonstrate QHL DSP HVX functions
+export fn qhl_dsp_demo() void {
+    const M_PI = 3.14159265358979323846;
+    const TAPS = 8;
+    var signal: [ARRAY_SIZE]f32 align(128) = undefined;
+    var coef: [TAPS]f32 align(128) = undefined;
+    var filtered: [ARRAY_SIZE]f32 align(128) = undefined;
+
+    _ = printf("  QHL DSP HVX Demo:\n");
+
+    // Generate a simple signal (sine wave)
+    for (0..ARRAY_SIZE) |i| {
+        const angle = 2.0 * M_PI * @as(f32, @floatFromInt(i)) / 8.0;
+        signal[i] = @sin(angle);
+    }
+
+    _ = printf("    FIR Filter Demo:\n");
+    _ = printf("      Input signal (sine wave): [%.3f, %.3f, %.3f, %.3f, ...]\n",
+        signal[0], signal[1], signal[2], signal[3]);
+
+    // Create averaging filter coefficients (low-pass filter)
+    const coef_value = 1.0 / @as(f32, @floatFromInt(TAPS));
+    for (0..TAPS) |i| {
+        coef[i] = coef_value;
+    }
+    _ = printf("      Filter: %d-tap averaging (low-pass), coefficients = %.4f\n", @as(c_int, TAPS), coef_value);
+
+    // Apply block FIR filter using QHL DSP HVX
+    const ret = qhdsp_hvx_bkfir_af(&signal, &coef, &filtered, ARRAY_SIZE, TAPS);
+    if (ret == 0) {
+        _ = printf("      Filtered output: [%.3f, %.3f, %.3f, %.3f, ...]\n",
+            filtered[0], filtered[1], filtered[2], filtered[3]);
+
+        // Calculate signal power before and after filtering
+        var input_power: f32 = 0.0;
+        var output_power: f32 = 0.0;
+        for (0..ARRAY_SIZE) |i| {
+            input_power += signal[i] * signal[i];
+            output_power += filtered[i] * filtered[i];
+        }
+
+        _ = printf("      Input signal power: %.4f\n", input_power);
+        _ = printf("      Filtered signal power: %.4f\n", output_power);
+
+        // Verify: Averaging filter should smooth the signal, power should be positive
+        std.debug.assert(input_power > 0.0);
+        std.debug.assert(output_power > 0.0);
+        std.debug.assert(output_power <= input_power * 1.5); // Filtered power should be similar
+        _ = printf("      [OK] Assertions passed\n");
+    } else {
+        _ = printf("      Block FIR filter failed with error: %d\n", ret);
+        _ = printf("      Note: Block FIR may have specific length requirements\n");
+
+        // Fallback: Calculate signal power manually to show something working
+        var total_power: f32 = 0.0;
+        for (0..ARRAY_SIZE) |i| {
+            total_power += signal[i] * signal[i];
+        }
+        _ = printf("      Signal power (fallback): %.4f\n", total_power);
+        _ = printf("      Average power: %.4f\n", total_power / @as(f32, @floatFromInt(ARRAY_SIZE)));
+        std.debug.assert(approxEqual(total_power / @as(f32, @floatFromInt(ARRAY_SIZE)), 0.5, 0.1));
+        _ = printf("      [OK] Fallback assertions passed\n");
+    }
+}
+
+// Demonstrate QHL complex number operations
+export fn qhl_complex_demo() void {
+    _ = printf("  QHL Complex Demo:\n");
+
+    // Test complex numbers using QHL's complex type
+    const z1 = float_complex{ .real = 3.0, .imag = 4.0 };
+    const z2 = float_complex{ .real = 1.0, .imag = -2.0 };
+
+    _ = printf("    z1 = %.1f + %.1fi\n", z1.real, z1.imag);
+    _ = printf("    z2 = %.1f + %.1fi\n", z2.real, z2.imag);
+
+    // Complex arithmetic using Zig (QHL complex uses C99 complex.h which isn't directly callable)
+    const add_real = z1.real + z2.real;
+    const add_imag = z1.imag + z2.imag;
+    _ = printf("    z1 + z2 = %.1f + %.1fi\n", add_real, add_imag);
+
+    const mul_real = z1.real * z2.real - z1.imag * z2.imag;
+    const mul_imag = z1.real * z2.imag + z1.imag * z2.real;
+    _ = printf("    z1 * z2 = %.1f + %.1fi\n", mul_real, mul_imag);
+
+    // Magnitude using QHL
+    const mag1 = qhcomplex_cabs_f(z1);
+    const mag2 = qhcomplex_cabs_f(z2);
+    _ = printf("    |z1| (QHL cabs) = %.4f\n", mag1);
+    _ = printf("    |z2| (QHL cabs) = %.4f\n", mag2);
+
+    // Phase using QHL
+    const phase1 = qhcomplex_carg_f(z1);
+    const phase2 = qhcomplex_carg_f(z2);
+    _ = printf("    arg(z1) (QHL carg) = %.4f radians\n", phase1);
+    _ = printf("    arg(z2) (QHL carg) = %.4f radians\n", phase2);
+
+    // Complex conjugate using QHL
+    const z1_conj = qhcomplex_conj_f(z1);
+    _ = printf("    conj(z1) (QHL) = %.1f + %.1fi\n", z1_conj.real, z1_conj.imag);
+
+    // Verify complex arithmetic
+    // z1 + z2 = (3+4i) + (1-2i) = 4+2i
+    std.debug.assert(approxEqual(add_real, 4.0, 0.001));
+    std.debug.assert(approxEqual(add_imag, 2.0, 0.001));
+
+    // z1 * z2 = (3+4i) * (1-2i) = 3 - 6i + 4i - 8i² = 11 - 2i
+    std.debug.assert(approxEqual(mul_real, 11.0, 0.001));
+    std.debug.assert(approxEqual(mul_imag, -2.0, 0.001));
+
+    // |z1| = sqrt(3^2 + 4^2) = 5.0
+    std.debug.assert(approxEqual(mag1, 5.0, 0.001));
+
+    // |z2| = sqrt(1^2 + 4) = sqrt(5) ~= 2.236
+    std.debug.assert(approxEqual(mag2, 2.2361, 0.001));
+
+    // conj(3+4i) = 3-4i
+    std.debug.assert(approxEqual(z1_conj.real, 3.0, 0.001));
+    std.debug.assert(approxEqual(z1_conj.imag, -4.0, 0.001));
+
+    _ = printf("    [OK] Assertions passed\n");
+}
+
+// Main entry point for QuRT's run_main_on_hexagon
+export fn main() c_int {
+    _ = printf("\n=== Zig QuRT + QHL Libraries Demo ===\n\n");
+
+    _ = printf("Testing QHL Math HVX Functions...\n");
+    qhl_math_demo();
+
+    _ = printf("\nTesting QHL BLAS HVX Functions...\n");
+    qhl_blas_demo();
+
+    _ = printf("\nTesting QHL DSP HVX Functions...\n");
+    qhl_dsp_demo();
+
+    _ = printf("\nTesting QHL Complex Functions...\n");
+    qhl_complex_demo();
+
+    _ = printf("\n=== Demo Complete ===\n");
+
+    return 0;
+}


### PR DESCRIPTION
Demonstrates using Zig's build system to target Qualcomm's QuRT RTOS with the QHL libs, including HVX-accelerated math, BLAS, DSP, and complex number operations.

The example builds a shared library using hexagon-clang that is loaded by run_main_on_hexagon_sim and executed on qemu-system-hexagon.

Requires Hexagon SDK 6.4.0.2 or compatible.
Supports architecture versions v68, v73, v75, v79, v81.