### PR TITLE
Add ${triple}-cc symlink; extend binutils links to bare hexagon triple

### DIFF
--- a/build-toolchain.sh
+++ b/build-toolchain.sh
@@ -122,7 +122,7 @@ build_llvm_clang() {
 add_symlinks() {
     linkdir=${1}
 
-	for triple in hexagon-unknown-linux-musl hexagon-unknown-none-elf hexagon-unknown-qurt hexagon-linux-musl hexagon-none-elf hexagon-qurt
+	for triple in hexagon-unknown-linux-musl hexagon-unknown-none-elf hexagon-unknown-qurt hexagon-linux-musl hexagon-none-elf hexagon-qurt hexagon
 	do
 		ln -sf --relative ${linkdir}/llvm-size ${linkdir}/${triple}-size
 		ln -sf --relative ${linkdir}/llvm-strip ${linkdir}/${triple}-strip
@@ -143,6 +143,7 @@ add_symlinks() {
 	do
 		ln -sf --relative ${linkdir}/clang ${linkdir}/${triple}-clang
 		ln -sf --relative ${linkdir}/clang ${linkdir}/${triple}-clang++
+		ln -sf --relative ${linkdir}/clang ${linkdir}/${triple}-cc
 	done
 }
 

--- a/debian-pkg/build-hexagon-sysroot.sh
+++ b/debian-pkg/build-hexagon-sysroot.sh
@@ -485,11 +485,12 @@ build_clang_hexagon_cross() {
     for triple in hexagon-unknown-linux-musl hexagon-unknown-none-elf \
                   hexagon-unknown-qurt hexagon-linux-musl hexagon-none-elf \
                   hexagon-qurt hexagon; do
-        # clang / clang++ -- versioned and unversioned
+        # clang / clang++ / cc -- versioned and unversioned
         for tool in clang clang++; do
             ln -sf "${clang_target}" "${bindir}/${triple}-${tool}"
             ln -sf "${clang_target}" "${bindir}/${triple}-${tool}-${LLVM_VERSION}"
         done
+        ln -sf "${clang_target}" "${bindir}/${triple}-cc"
 
         # binutils-like tools
         for tool in ar ranlib nm objcopy objdump readelf strip size; do


### PR DESCRIPTION
Both the tarball build (build-toolchain.sh add_symlinks) and the Debian meta-package (build-hexagon-sysroot.sh build_clang_hexagon_cross) now create a ${triple}-cc symlink pointing to clang, matching the POSIX/autoconf convention for the C compiler driver.

Also extend the binutils symlink loop in build-toolchain.sh to include the bare 'hexagon' triple (size, strip, nm, ar, objdump, objcopy, readelf, ranlib, ld.lld, ld.eld), matching the existing behaviour in the Debian packaging and the clang/clang++/cc loop.