### PR TITLE
Add llvm-mc, llvm-strings, llvm-addr2line to distribution components

### DIFF
--- a/build-toolchain.sh
+++ b/build-toolchain.sh
@@ -34,10 +34,10 @@ build_llvm_clang_cross() {
 	# (LLD is sufficient); only the native build includes ld.eld.
 	DIST_COMPONENTS=(
 		clang clang-resource-headers lld LTO
-		llvm-ar llvm-config llvm-cov llvm-cxxfilt llvm-dwarfdump
-		llvm-nm llvm-objcopy llvm-objdump llvm-profdata
+		llvm-addr2line llvm-ar llvm-config llvm-cov llvm-cxxfilt llvm-dwarfdump
+		llvm-mc llvm-nm llvm-objcopy llvm-objdump llvm-profdata
 		llvm-ranlib llvm-readelf llvm-readobj
-		llvm-size llvm-strip llvm-symbolizer
+		llvm-size llvm-strings llvm-strip llvm-symbolizer
 	)
 	DYLIB=""
 	if [[ "${dylib}" == "ON" ]]; then

--- a/cmake/caches/hexagon-stage0.cmake
+++ b/cmake/caches/hexagon-stage0.cmake
@@ -36,11 +36,13 @@ set(LLVM_ENABLE_ZSTD ON CACHE BOOL "")
 
 # Distribution components -- installed via `--target install-distribution`
 set(LLVM_TOOLCHAIN_TOOLS
+  llvm-addr2line
   llvm-ar
   llvm-config
   llvm-cov
   llvm-cxxfilt
   llvm-dwarfdump
+  llvm-mc
   llvm-nm
   llvm-objcopy
   llvm-objdump
@@ -49,6 +51,7 @@ set(LLVM_TOOLCHAIN_TOOLS
   llvm-readelf
   llvm-readobj
   llvm-size
+  llvm-strings
   llvm-strip
   llvm-symbolizer
   CACHE STRING "")


### PR DESCRIPTION
These tools were omitted from LLVM_DISTRIBUTION_COMPONENTS in the cmake cache and from DIST_COMPONENTS in the cross-build function. Both lists are kept in sync.