### PR TITLE
Add four standalone scripts under sysroot-scripts/

### DIFF
--- a/.github/workflows/build-sysroot.yml
+++ b/.github/workflows/build-sysroot.yml
@@ -1,0 +1,549 @@
+# build-sysroot.yml
+#
+# Builds a Hexagon sysroot (compiler-rt builtins, picolibc, H2, runtimes)
+# on top of a freshly-built Hexagon LLVM/Clang toolchain, all from latest
+# upstream sources.
+#
+# Three jobs:
+#   build-toolchain  - builds clang/llvm-tools + ELD (no lld, no builtins)
+#                      from latest llvm-project (main) and eld (main).
+#                      Installs into Tools/ so the sysroot scripts can install
+#                      directly into the same tree (bin/../target/picolibc/...)
+#                      matching the DEFAULT_SYSROOT compiled into clang.
+#                      Uploads the toolchain as an intermediate artifact.
+#   build-qemu       - builds qemu-system-hexagon from quic/qemu; uploads
+#                      the binary as an intermediate artifact.  Required by the
+#                      H2 build to execute the asm_offsets generator ELF.
+#   build-sysroot    - downloads the toolchain and qemu, fetches latest
+#                      llvm-project (compiler-rt + runtimes), picolibc (main),
+#                      and H2 (quic-k/hexagon-hypervisor@upstream-toolchain),
+#                      then runs the four sysroot-build scripts in order:
+#                        1. build_hexagon_builtins.sh
+#                        2. build_hexagon_picolibc.sh
+#                        3. build_hexagon_h2.sh  (uses qemu-system-hexagon)
+#                        4. build_hexagon_runtimes.sh
+#                      Each script installs into ${TC_ROOT}/Tools/target/picolibc/
+#                      so clang can find the sysroot for the next script.
+#                      Uploads only the sysroot subtree as the final artifact.
+#
+# Trigger: manual (workflow_dispatch) or PR (temporary, for testing).
+
+name: Build Hexagon Sysroot
+
+on:
+  # TODO: remove pull_request once CI is validated
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      llvm_ref:
+        description: 'llvm-project branch/tag/SHA to build clang and sysroot libs from'
+        required: false
+        default: 'main'
+      eld_ref:
+        description: 'qualcomm/eld branch/tag/SHA'
+        required: false
+        default: 'main'
+      picolibc_ref:
+        description: 'picolibc branch/tag/SHA'
+        required: false
+        default: 'main'
+      h2_repo:
+        description: 'H2 (hexagon-hypervisor) repository URL'
+        required: false
+        default: 'https://github.com/quic-k/hexagon-hypervisor'
+      h2_ref:
+        description: 'H2 repository branch/tag/SHA'
+        required: false
+        default: 'upstream-toolchain'
+      qemu_ref:
+        description: 'quic/qemu branch/tag/SHA for qemu-system-hexagon'
+        required: false
+        default: 'hexagon-sysemu-11-nov-2025'
+      build_cores:
+        description: 'Space-separated Hexagon arch versions to fully build (others are symlinked)'
+        required: false
+        default: 'v68'
+      all_cores:
+        description: 'Space-separated full set of Hexagon arch versions to install for'
+        required: false
+        default: 'v68 v69 v71 v71t v73 v75 v77 v79 v81 v83 v85 v87 v89 v91'
+
+# ---------------------------------------------------------------------------
+# Shared constants
+# ---------------------------------------------------------------------------
+env:
+  # Toolchain is installed into TC_ROOT/Tools/ so that the sysroot scripts
+  # can set INSTALLPATH=TC_ROOT and have ${INSTALLPATH}/Tools/target/picolibc/
+  # land exactly where clang's DEFAULT_SYSROOT (bin/../target/picolibc/) looks.
+  TC_ROOT: ${{ github.workspace }}/hexagon-toolchain
+
+# ---------------------------------------------------------------------------
+# Job A: build-toolchain
+# ---------------------------------------------------------------------------
+jobs:
+  build-toolchain:
+    name: Build Hexagon Clang + ELD, no lld (latest)
+    runs-on: ubuntu-latest
+
+    # Resolve all inputs once; steps reference ${{ env.LLVM_REF }} etc.
+    # The || fallbacks ensure PR runs (where inputs are empty) use defaults.
+    env:
+      LLVM_REF: ${{ inputs.llvm_ref || 'main' }}
+      ELD_REF:  ${{ inputs.eld_ref  || 'main' }}
+
+    steps:
+      - name: Checkout repository (for cmake/caches and config files)
+        uses: actions/checkout@v4
+
+      # -----------------------------------------------------------------------
+      # Free up disk space — the default ubuntu-latest image ships ~30 GB of
+      # pre-installed software we don't need (Android SDK, .NET, etc.).
+      # -----------------------------------------------------------------------
+      - name: Free disk space
+        run: |
+          sudo rm -rf \
+            /usr/local/lib/android \
+            /usr/share/dotnet \
+            /opt/ghc \
+            /usr/local/.ghcup \
+            /usr/local/share/boost \
+            "$AGENT_TOOLSDIRECTORY" || true
+          df -h
+
+      # -----------------------------------------------------------------------
+      # Host build dependencies
+      # -----------------------------------------------------------------------
+      - name: Install host build dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            cmake \
+            ninja-build \
+            clang \
+            libc++-dev \
+            libc++abi-dev \
+            python3 \
+            zlib1g-dev \
+            libzstd-dev \
+            zstd \
+            ccache \
+            git \
+            lsb-release
+
+      # -----------------------------------------------------------------------
+      # Clone sources
+      # -----------------------------------------------------------------------
+      - name: Clone llvm-project (${{ env.LLVM_REF }})
+        run: |
+          git clone \
+            --depth 1 \
+            --branch "${{ env.LLVM_REF }}" \
+            https://github.com/llvm/llvm-project.git \
+            llvm-project
+
+      - name: Clone ELD into llvm-project/eld (${{ env.ELD_REF }})
+        run: |
+          git clone \
+            --depth 1 \
+            --branch "${{ env.ELD_REF }}" \
+            https://github.com/qualcomm/eld.git \
+            llvm-project/eld
+
+      # -----------------------------------------------------------------------
+      # Configure LLVM/Clang + ELD
+      # Settings are inlined directly rather than using the repo's cmake cache
+      # files (hexagon-stage0.cmake / hexagon-stage0-cross.cmake) because those
+      # set DEFAULT_SYSROOT to "../target/hexagon-unknown-linux-musl/" which
+      # causes clang's getEffectiveSysRoot() to return the (non-existent) musl
+      # sysroot even for --cstdlib=picolibc, preventing picolibc headers from
+      # being found.  With no DEFAULT_SYSROOT, the Hexagon driver correctly
+      # resolves picolibc to bin/../target/picolibc/<triple>/.
+      # -----------------------------------------------------------------------
+      - name: Configure LLVM/Clang + ELD
+        run: |
+          cmake -G Ninja \
+            -DCMAKE_INSTALL_PREFIX="${TC_ROOT}/Tools" \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_CXX_COMPILER=clang++ \
+            -DCMAKE_CXX_FLAGS="-stdlib=libc++" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_BUILD_WITH_INSTALL_RPATH=1 \
+            -DCMAKE_INSTALL_RPATH="\$ORIGIN/../lib" \
+            -DCMAKE_SKIP_INSTALL_ALL_DEPENDENCY=ON \
+            -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON \
+            -DLLVM_TARGETS_TO_BUILD="Hexagon" \
+            -DLLVM_ENABLE_PROJECTS="clang" \
+            -DLLVM_ENABLE_PIC=ON \
+            -DLLVM_BUILD_LLVM_DYLIB=OFF \
+            -DLLVM_LINK_LLVM_DYLIB=OFF \
+            -DLLVM_BUILD_RUNTIME=OFF \
+            -DLIBCLANG_BUILD_STATIC=ON \
+            -DLLVM_VERSION_SUFFIX="" \
+            -DLLVM_DEFAULT_TARGET_TRIPLE="hexagon-unknown-none-elf" \
+            -DLLVM_ENABLE_LIBCXX=ON \
+            -DLLVM_ENABLE_ASSERTIONS=ON \
+            -DLLVM_CCACHE_BUILD=ON \
+            -DLLVM_INSTALL_TOOLCHAIN_ONLY=OFF \
+            -DLLVM_INCLUDE_TESTS=OFF \
+            -DLLVM_INCLUDE_DOCS=OFF \
+            -DLLVM_INCLUDE_BENCHMARKS=OFF \
+            -DLLVM_BUILD_BENCHMARKS=OFF \
+            -DLLVM_ENABLE_ZLIB=ON \
+            -DLLVM_ENABLE_ZSTD=ON \
+            -DCLANG_DEFAULT_CXX_STDLIB="libc++" \
+            -DCLANG_DEFAULT_RTLIB="compiler-rt" \
+            -DCLANG_DEFAULT_UNWINDLIB="libunwind" \
+            -DCLANG_DEFAULT_OBJCOPY="llvm-objcopy" \
+            -DLLVM_EXTERNAL_PROJECTS=eld \
+            -DLLVM_EXTERNAL_ELD_SOURCE_DIR="${GITHUB_WORKSPACE}/llvm-project/eld" \
+            -DELD_ENABLE_SYMBOL_VERSIONING=ON \
+            -DELD_TARGETS_TO_BUILD=Hexagon \
+            -DLLVM_DISTRIBUTION_COMPONENTS="clang;clang-resource-headers;llvm-ar;llvm-config;llvm-cov;llvm-cxxfilt;llvm-dwarfdump;llvm-mc;llvm-nm;llvm-objcopy;llvm-objdump;llvm-profdata;llvm-ranlib;llvm-readobj;llvm-size;llvm-strings;llvm-strip;llvm-symbolizer" \
+            -B obj_llvm \
+            -S llvm-project/llvm
+
+      # -----------------------------------------------------------------------
+      # Build and install
+      # -----------------------------------------------------------------------
+      - name: Build and install clang/llvm-tools (install-distribution)
+        run: cmake --build obj_llvm --target install-distribution
+
+      - name: Build and install ELD (install-ld.eld)
+        run: cmake --build obj_llvm --target install-ld.eld
+
+      # -----------------------------------------------------------------------
+      # Create symlinks required by the picolibc meson cross-file.
+      # The cross-file hardcodes these four tool names and 'eld' as the
+      # linker; cmake install provides the llvm-* originals but not the
+      # hexagon-* aliases or the bare 'eld' name.
+      # The clang/clang++ scripts fall back to plain 'clang'/'clang++'
+      # automatically, so no hexagon-clang symlink is needed.
+      # -----------------------------------------------------------------------
+      - name: Create symlinks for picolibc meson cross-file tools
+        run: |
+          BIN="${TC_ROOT}/Tools/bin"
+
+          ln -sf --relative "${BIN}/llvm-ar"      "${BIN}/hexagon-ar"
+          ln -sf --relative "${BIN}/llvm-nm"      "${BIN}/hexagon-nm"
+          ln -sf llvm-strip                        "${BIN}/hexagon-strip"
+          ln -sf --relative "${BIN}/llvm-objcopy" "${BIN}/hexagon-llvm-objcopy"
+
+          # 'eld' bare name — required by the picolibc meson cross-file
+          # (c_ld = 'eld') which meson resolves via PATH.
+          if [[ -e "${BIN}/ld.eld" ]]; then
+            ln -sf --relative "${BIN}/ld.eld" "${BIN}/eld"
+          fi
+
+          echo "Symlinks created in ${BIN}:"
+          ls -la "${BIN}" | grep -E "^l"
+
+      # -----------------------------------------------------------------------
+      # Package and upload the toolchain
+      # -----------------------------------------------------------------------
+      - name: Package toolchain
+        run: |
+          tar \
+            --use-compress-program "zstd -T0 -9" \
+            -cf hexagon-toolchain.tar.zst \
+            -C "${TC_ROOT}" \
+            Tools
+          du -sh hexagon-toolchain.tar.zst
+
+      - name: Upload toolchain artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: hexagon-toolchain
+          path: hexagon-toolchain.tar.zst
+          retention-days: 3
+
+# ---------------------------------------------------------------------------
+# Job B: build-qemu
+# ---------------------------------------------------------------------------
+  build-qemu:
+    name: Build qemu-system-hexagon (${{ inputs.qemu_ref || 'hexagon-sysemu-11-nov-2025' }})
+    runs-on: ubuntu-latest
+
+    env:
+      QEMU_REF: ${{ inputs.qemu_ref || 'hexagon-sysemu-11-nov-2025' }}
+
+    steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf \
+            /usr/local/lib/android \
+            /usr/share/dotnet \
+            /opt/ghc \
+            /usr/local/.ghcup \
+            /usr/local/share/boost \
+            "$AGENT_TOOLSDIRECTORY" || true
+          df -h
+
+      # QEMU's configure script requires a broad set of host libraries.
+      - name: Install QEMU build dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            git \
+            ninja-build \
+            python3 \
+            python3-pip \
+            python3-venv \
+            pkg-config \
+            libglib2.0-dev \
+            libslirp-dev \
+            libpixman-1-dev \
+            libcap-ng-dev \
+            libattr1-dev \
+            libzstd-dev \
+            zlib1g-dev \
+            flex \
+            bison
+
+      - name: Clone quic/qemu (${{ env.QEMU_REF }})
+        run: |
+          git clone \
+            --depth 1 \
+            --branch "${{ env.QEMU_REF }}" \
+            https://github.com/quic/qemu.git \
+            qemu
+
+      # Build hexagon-softmmu with fdt bundled internally so the binary has
+      # no libfdt.so runtime dependency when downloaded in build-sysroot.
+      # Docs are disabled to avoid heavy doc-build toolchain requirements.
+      - name: Configure QEMU (hexagon-softmmu)
+        run: |
+          mkdir obj_qemu
+          cd obj_qemu
+          ../qemu/configure \
+            --target-list=hexagon-softmmu \
+            --prefix="${GITHUB_WORKSPACE}/qemu-install" \
+            --enable-fdt=internal \
+            --disable-docs \
+            --disable-containers \
+            --extra-cflags="-Wno-error=misleading-indentation"
+
+      - name: Build and install QEMU
+        run: |
+          make -C obj_qemu -j$(nproc)
+          make -C obj_qemu install
+
+      - name: Verify qemu-system-hexagon
+        run: |
+          "${GITHUB_WORKSPACE}/qemu-install/bin/qemu-system-hexagon" --version
+
+      - name: Package qemu-system-hexagon
+        run: |
+          tar \
+            --use-compress-program "zstd -T0 -9" \
+            -cf qemu-hexagon.tar.zst \
+            -C "${GITHUB_WORKSPACE}/qemu-install" \
+            bin/qemu-system-hexagon
+          du -sh qemu-hexagon.tar.zst
+
+      - name: Upload qemu artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: qemu-hexagon
+          path: qemu-hexagon.tar.zst
+          retention-days: 3
+
+# ---------------------------------------------------------------------------
+# Job C: build-sysroot
+# ---------------------------------------------------------------------------
+  build-sysroot:
+    name: Build Hexagon Sysroot (builtins + picolibc + H2 + runtimes)
+    runs-on: ubuntu-latest
+    needs: [build-toolchain, build-qemu]
+
+    env:
+      LLVM_REF:     ${{ inputs.llvm_ref     || 'main' }}
+      PICOLIBC_REF: ${{ inputs.picolibc_ref || 'main' }}
+      H2_REPO:      ${{ inputs.h2_repo      || 'https://github.com/quic-k/hexagon-hypervisor' }}
+      H2_REF:       ${{ inputs.h2_ref       || 'upstream-toolchain' }}
+      BUILD_CORES:  ${{ inputs.build_cores  || 'v68' }}
+      ALL_CORES:    ${{ inputs.all_cores    || 'v68 v69 v71 v71t v73 v75 v77 v79 v81 v83 v85 v87 v89 v91' }}
+
+    steps:
+      - name: Checkout repository (for the sysroot-scripts/ directory)
+        uses: actions/checkout@v4
+
+      # -----------------------------------------------------------------------
+      # Free up disk space
+      # -----------------------------------------------------------------------
+      - name: Free disk space
+        run: |
+          sudo rm -rf \
+            /usr/local/lib/android \
+            /usr/share/dotnet \
+            /opt/ghc \
+            /usr/local/.ghcup \
+            /usr/local/share/boost \
+            "$AGENT_TOOLSDIRECTORY" || true
+          df -h
+
+      # -----------------------------------------------------------------------
+      # Host build dependencies
+      # -----------------------------------------------------------------------
+      - name: Install host build dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            cmake \
+            ninja-build \
+            make \
+            python3-pip \
+            git \
+            zstd \
+            libc++1 \
+            libc++abi1 \
+            libglib2.0-0
+          pip3 install --quiet meson
+
+      # -----------------------------------------------------------------------
+      # Restore the toolchain built in Job A.
+      # Extracts into TC_ROOT/Tools/ so:
+      #   TOOLCHAIN  = TC_ROOT/Tools          (bin/clang lives here)
+      #   INSTALLPATH = TC_ROOT               (scripts write to INSTALLPATH/Tools/...)
+      # Each script installs into TC_ROOT/Tools/target/picolibc/ — exactly
+      # where clang's DEFAULT_SYSROOT resolves, so each successive script
+      # can use the libraries installed by the previous one.
+      # -----------------------------------------------------------------------
+      - name: Download toolchain artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: hexagon-toolchain
+          path: ${{ github.workspace }}
+
+      - name: Extract toolchain
+        run: |
+          mkdir -p "${TC_ROOT}"
+          tar \
+            --use-compress-program "zstd -d" \
+            -xf hexagon-toolchain.tar.zst \
+            -C "${TC_ROOT}"
+          echo "Toolchain bin contents:"
+          ls "${TC_ROOT}/Tools/bin" | head -20
+
+      - name: Add toolchain to PATH
+        run: echo "${TC_ROOT}/Tools/bin" >> "$GITHUB_PATH"
+
+      # -----------------------------------------------------------------------
+      # Restore qemu-system-hexagon built in Job B
+      # -----------------------------------------------------------------------
+      - name: Download qemu artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: qemu-hexagon
+          path: ${{ github.workspace }}
+
+      - name: Extract and add qemu-system-hexagon to PATH
+        run: |
+          tar \
+            --use-compress-program "zstd -d" \
+            -xf qemu-hexagon.tar.zst \
+            -C "$GITHUB_WORKSPACE"
+          echo "${GITHUB_WORKSPACE}/bin" >> "$GITHUB_PATH"
+          echo "qemu-system-hexagon version:"
+          "${GITHUB_WORKSPACE}/bin/qemu-system-hexagon" --version
+
+      # -----------------------------------------------------------------------
+      # Clone sources needed by the four scripts
+      # -----------------------------------------------------------------------
+      - name: Clone llvm-project (${{ env.LLVM_REF }}) for compiler-rt + runtimes
+        run: |
+          git clone \
+            --depth 1 \
+            --branch "${{ env.LLVM_REF }}" \
+            https://github.com/llvm/llvm-project.git \
+            sources/llvm-project
+
+      - name: Clone picolibc (${{ env.PICOLIBC_REF }})
+        run: |
+          git clone \
+            --depth 1 \
+            --branch "${{ env.PICOLIBC_REF }}" \
+            https://github.com/picolibc/picolibc.git \
+            sources/picolibc
+
+      - name: Clone H2 / hexagon-hypervisor (${{ env.H2_REPO }}@${{ env.H2_REF }})
+        run: |
+          git clone \
+            --depth 1 \
+            --branch "${{ env.H2_REF }}" \
+            "${{ env.H2_REPO }}" \
+            sources/hexagon-hypervisor
+
+      # -----------------------------------------------------------------------
+      # Shared environment for all four scripts.
+      # TOOLCHAIN = TC_ROOT/Tools  (bin/clang, bin/hexagon-ar, etc.)
+      # INSTALLPATH = TC_ROOT      (scripts write to INSTALLPATH/Tools/target/...)
+      # This ensures each script's output is immediately visible to clang for
+      # the next script (e.g. picolibc headers available when building H2).
+      # -----------------------------------------------------------------------
+      - name: Set sysroot build environment
+        run: |
+          echo "TOOLCHAIN=${TC_ROOT}/Tools"                             >> "$GITHUB_ENV"
+          echo "SOURCECODE=${GITHUB_WORKSPACE}/sources/llvm-project"   >> "$GITHUB_ENV"
+          echo "PICOLIBC_SRC=${GITHUB_WORKSPACE}/sources/picolibc"     >> "$GITHUB_ENV"
+          echo "H2_SRC=${GITHUB_WORKSPACE}/sources/hexagon-hypervisor" >> "$GITHUB_ENV"
+          echo "BUILDPATH=${GITHUB_WORKSPACE}/build"                   >> "$GITHUB_ENV"
+          echo "INSTALLPATH=${TC_ROOT}"                                 >> "$GITHUB_ENV"
+          echo "BUILD_CORES=${BUILD_CORES}"                            >> "$GITHUB_ENV"
+          echo "ALL_CORES=${ALL_CORES}"                                >> "$GITHUB_ENV"
+          echo "JOBS=$(nproc)"                                         >> "$GITHUB_ENV"
+
+      # -----------------------------------------------------------------------
+      # Step 1 of 4: compiler-rt builtins
+      # -----------------------------------------------------------------------
+      - name: '[1/4] Build compiler-rt builtins'
+        run: bash sysroot-scripts/build_hexagon_builtins.sh
+
+      # -----------------------------------------------------------------------
+      # Step 2 of 4: picolibc
+      # -----------------------------------------------------------------------
+      - name: '[2/4] Build picolibc'
+        run: bash sysroot-scripts/build_hexagon_picolibc.sh
+
+      # -----------------------------------------------------------------------
+      # Step 3 of 4: H2 libraries
+      # -----------------------------------------------------------------------
+      - name: '[3/4] Build H2 libraries'
+        run: bash sysroot-scripts/build_hexagon_h2.sh
+
+      # -----------------------------------------------------------------------
+      # Step 4 of 4: runtimes (libunwind, libc++abi, libc++)
+      # -----------------------------------------------------------------------
+      - name: '[4/4] Build runtimes (libunwind + libc++abi + libc++)'
+        run: bash sysroot-scripts/build_hexagon_runtimes.sh
+
+      # -----------------------------------------------------------------------
+      # Package and upload the sysroot subtree only.
+      # The full toolchain (bin/, lib/, etc.) is not re-uploaded; only the
+      # newly built target/picolibc/<triple>/ trees are shipped as the artifact.
+      # -----------------------------------------------------------------------
+      - name: Show sysroot install tree
+        run: |
+          echo "=== Sysroot install tree ==="
+          find "${TC_ROOT}/Tools/target/picolibc" -type f | sort
+          echo ""
+          echo "=== Disk usage ==="
+          du -sh "${TC_ROOT}/Tools/target/picolibc"
+
+      - name: Package sysroot
+        run: |
+          SYSROOT_TARBALL="hexagon-sysroot-${{ github.sha }}.tar.zst"
+          tar \
+            --use-compress-program "zstd -T0 -9" \
+            -chf "${SYSROOT_TARBALL}" \
+            -C "${TC_ROOT}/Tools/target" \
+            picolibc
+          echo "SYSROOT_TARBALL=${SYSROOT_TARBALL}" >> "$GITHUB_ENV"
+          du -sh "${SYSROOT_TARBALL}"
+
+      - name: Upload sysroot artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: hexagon-sysroot
+          path: ${{ env.SYSROOT_TARBALL }}
+          retention-days: 14

--- a/sysroot-scripts/build_hexagon_builtins.sh
+++ b/sysroot-scripts/build_hexagon_builtins.sh
@@ -1,0 +1,314 @@
+#!/usr/bin/env bash
+# build_builtins.sh
+#
+# Builds compiler-rt builtins for Hexagon baremetal, one build per core.
+# Produces three install trees from a single build:
+#   target/picolibc/hexagon-unknown-none-elf/  (built directly, for --cstdlib=picolibc)
+#   target/picolibc/hexagon-unknown-h2-elf/    (symlinked from none-elf, for --cstdlib=picolibc)
+#   target/picolibc/hexagon-unknown-qurt-elf/  (copied from none-elf, for --cstdlib=picolibc)
+#
+# Required environment variables:
+#   TOOLCHAIN    - Path to the installed Hexagon LLVM toolchain
+#                  e.g. /path/to/inst/Tools
+#   SOURCECODE   - Path to the llvm-top source directory
+#                  e.g. /path/to/build/llvm-top
+#   BUILDPATH    - Root directory for all build artifacts
+#                  e.g. /path/to/build
+#   INSTALLPATH  - Root directory where libs are installed
+#                  e.g. /path/to/install
+#
+# Optional environment variables:
+#   BUILD_CORES  - Space-separated list of Hexagon arch versions to actually build
+#                  (default: "v68")
+#   ALL_CORES    - Space-separated list of all Hexagon arch versions to install for
+#                  (default: "v68 v69 v71 v71t v73 v75 v77 v79 v81 v83 v85 v87 v89 v91")
+#   NINJA        - Path to the ninja executable (default: ninja)
+#   JOBS         - Parallel jobs for ninja (default: number of CPU cores)
+#
+# Build layout under BUILDPATH:
+#   compiler-rt/
+#     build-hexagon-<core>-builtins/      (cmake build dir, non-G0)
+#     build-hexagon-<core>-builtins-G0/   (cmake build dir, G0)
+#     build-hexagon-<core>-builtins-G0-pic/ (cmake build dir, G0 + PIC)
+#     install/<core>/                     (intermediate install, non-G0)
+#     install/<core>-G0/                  (intermediate install, G0)
+#     install/<core>-G0-pic/              (intermediate install, G0 + PIC)
+#
+# Install layout under INSTALLPATH (flat variant directories):
+#   target/
+#     picolibc/
+#       hexagon-unknown-none-elf/
+#         lib/<core>/
+#           libclang_rt.builtins.a          (non-G0, built)
+#         lib/<core>-G0/
+#           libclang_rt.builtins.a          (G0, built)
+#         lib/<core>-G0-pic/
+#           libclang_rt.builtins.a          (G0 + PIC, built)
+#         lib/<other-core>[-G0[-pic]]/<file> -> ../<core>[-G0[-pic]]/<file>  (per-file symlinks for non-built cores)
+#       hexagon-unknown-h2-elf/
+#         lib/<core>[-G0[-pic]]/<file> -> ../../hexagon-unknown-none-elf/lib/<core>[-G0[-pic]]/<file>  (per-file symlinks)
+#       hexagon-unknown-qurt-elf/
+#         lib/  (full copy of hexagon-unknown-none-elf/lib/)
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Validate required environment variables
+# ---------------------------------------------------------------------------
+: "${TOOLCHAIN:?'TOOLCHAIN env var is required (path to installed Hexagon LLVM toolchain)'}"
+: "${SOURCECODE:?'SOURCECODE env var is required (path to llvm-top source directory)'}"
+: "${BUILDPATH:?'BUILDPATH env var is required (root directory for all build artifacts)'}"
+: "${INSTALLPATH:?'INSTALLPATH env var is required (root directory where libs are installed)'}"
+
+# ---------------------------------------------------------------------------
+# Defaults for optional variables
+# ---------------------------------------------------------------------------
+BUILD_CORES="${BUILD_CORES:-v68}"
+ALL_CORES="${ALL_CORES:-v68 v69 v71 v71t v73 v75 v77 v79 v81 v83 v85 v87 v89 v91}"
+NINJA="${NINJA:-ninja}"
+JOBS="${JOBS:-$(nproc)}"
+
+# ---------------------------------------------------------------------------
+# Derived paths
+# ---------------------------------------------------------------------------
+CLANG="${TOOLCHAIN}/bin/hexagon-clang"
+CLANGXX="${TOOLCHAIN}/bin/hexagon-clang++"
+
+# Fall back to plain clang/clang++ if hexagon-prefixed variants are absent.
+[[ -x "${CLANG}"   ]] || CLANG="${TOOLCHAIN}/bin/clang"
+[[ -x "${CLANGXX}" ]] || CLANGXX="${TOOLCHAIN}/bin/clang++"
+
+COMPILER_RT_SRC="${SOURCECODE}/compiler-rt"
+
+COMPILER_RT_BUILD_ROOT="${BUILDPATH}/compiler-rt"
+COMPILER_RT_INSTALL_ROOT="${BUILDPATH}/compiler-rt/install"
+
+FINAL_INSTALL="${INSTALLPATH}/Tools"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+log() { echo "[$(date '+%H:%M:%S')] $*"; }
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+require_tool() {
+    command -v "$1" >/dev/null 2>&1 || die "'$1' not found in PATH"
+}
+
+# ---------------------------------------------------------------------------
+# Pre-flight checks
+# ---------------------------------------------------------------------------
+log "=== Pre-flight checks ==="
+require_tool cmake
+require_tool "${NINJA}"
+
+[[ -x "${CLANG}" ]]   || die "hexagon-clang/clang not found (tried ${TOOLCHAIN}/bin/hexagon-clang and ${TOOLCHAIN}/bin/clang)"
+[[ -x "${CLANGXX}" ]] || die "hexagon-clang++/clang++ not found (tried ${TOOLCHAIN}/bin/hexagon-clang++ and ${TOOLCHAIN}/bin/clang++)"
+[[ -d "${COMPILER_RT_SRC}" ]] || die "compiler-rt source not found at ${COMPILER_RT_SRC}"
+
+mkdir -p "${COMPILER_RT_BUILD_ROOT}" "${COMPILER_RT_INSTALL_ROOT}"
+
+# ---------------------------------------------------------------------------
+# Build compiler-rt builtins (G0 and non-G0, one build per core per variant)
+# ---------------------------------------------------------------------------
+log "=== Building compiler-rt builtins ==="
+log "Building for cores: ${BUILD_CORES}"
+log "Will copy to all cores: ${ALL_CORES}"
+
+for CORE in ${BUILD_CORES}; do
+    for VARIANT in "non-G0" "G0" "G0-pic"; do
+        if [[ "${VARIANT}" == "G0" ]]; then
+            VARIANT_SUFFIX="-G0"
+            G0_FLAG="-G0"
+            DEST_SUFFIX="-G0"
+            PIC_ENABLED="OFF"
+            PIC_FLAG=""
+            EXTRA_FLAGS="-O3 -ffunction-sections -fdata-sections"
+        elif [[ "${VARIANT}" == "G0-pic" ]]; then
+            VARIANT_SUFFIX="-G0-pic"
+            G0_FLAG="-G0"
+            DEST_SUFFIX="-G0-pic"
+            PIC_ENABLED="ON"
+            PIC_FLAG="-fPIC"
+            EXTRA_FLAGS="-O3 -ffunction-sections -fdata-sections -fvisibility=hidden"
+        else
+            VARIANT_SUFFIX=""
+            G0_FLAG=""
+            DEST_SUFFIX=""
+            PIC_ENABLED="OFF"
+            PIC_FLAG=""
+            EXTRA_FLAGS="-O3 -ffunction-sections -fdata-sections"
+        fi
+
+        log "--- compiler-rt builtins: ${CORE}${VARIANT_SUFFIX} ---"
+
+        BUILD_DIR="${COMPILER_RT_BUILD_ROOT}/build-hexagon-${CORE}-builtins${VARIANT_SUFFIX}"
+        BUILTINS_INSTALL_DIR="${COMPILER_RT_INSTALL_ROOT}/${CORE}${VARIANT_SUFFIX}"
+        mkdir -p "${BUILD_DIR}" "${BUILTINS_INSTALL_DIR}"
+
+        cmake -G Ninja \
+            -DCMAKE_C_COMPILER="${CLANG}" \
+            -DCMAKE_CXX_COMPILER="${CLANGXX}" \
+            -DCMAKE_ASM_FLAGS="${G0_FLAG} -mlong-calls -m${CORE} ${PIC_FLAG} ${EXTRA_FLAGS} --cstdlib=picolibc" \
+            -DCMAKE_C_FLAGS="${G0_FLAG} -ffreestanding -m${CORE} ${PIC_FLAG} ${EXTRA_FLAGS} --cstdlib=picolibc" \
+            -DCMAKE_CXX_FLAGS="${G0_FLAG} -ffreestanding -m${CORE} ${PIC_FLAG} ${EXTRA_FLAGS} --cstdlib=picolibc" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="${BUILTINS_INSTALL_DIR}" \
+            -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR:BOOL=ON \
+            -DLLVM_TARGET_TRIPLE=hexagon-unknown-none-elf \
+            -DCOMPILER_RT_DEFAULT_TARGET_TRIPLE=hexagon-unknown-none-elf \
+            -DCOMPILER_RT_BUILD_BUILTINS:BOOL=ON \
+            -DCOMPILER_RT_BUILD_SANITIZERS:BOOL=OFF \
+            -DCOMPILER_RT_BUILD_XRAY:BOOL=OFF \
+            -DCOMPILER_RT_BUILD_LIBFUZZER:BOOL=OFF \
+            -DCOMPILER_RT_BUILD_PROFILE:BOOL=OFF \
+            -DCOMPILER_RT_BUILD_MEMPROF:BOOL=OFF \
+            -DCOMPILER_RT_BUILD_ORC:BOOL=OFF \
+            -DCOMPILER_RT_BUILD_GWP_ASAN:BOOL=OFF \
+            -DCOMPILER_RT_BUILTINS_ENABLE_PIC:BOOL=${PIC_ENABLED} \
+            -DCOMPILER_RT_SUPPORTED_ARCH=hexagon \
+            -DCOMPILER_RT_BAREMETAL_BUILD:BOOL=ON \
+            -DCMAKE_CROSSCOMPILING:BOOL=ON \
+            -DCAN_TARGET_hexagon=1 \
+            -DCMAKE_C_COMPILER_FORCED:BOOL=ON \
+            -DCMAKE_CXX_COMPILER_FORCED:BOOL=ON \
+            -DCMAKE_C_COMPILER_TARGET=hexagon-unknown-none-elf \
+            -DCMAKE_CXX_COMPILER_TARGET=hexagon-unknown-none-elf \
+            -B "${BUILD_DIR}" \
+            -S "${COMPILER_RT_SRC}"
+
+        cmake --build "${BUILD_DIR}" -j"${JOBS}" -- install-builtins
+
+        # Copy the built library into the final install tree.
+        # With LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=ON the library lands at:
+        #   <prefix>/lib/hexagon-unknown-none-elf/libclang_rt.builtins.a
+        BUILTIN_LIB_DIR="${BUILTINS_INSTALL_DIR}/lib/hexagon-unknown-none-elf"
+        DEST_DIR="${FINAL_INSTALL}/target/picolibc/hexagon-unknown-none-elf/lib/${CORE}${DEST_SUFFIX}"
+        mkdir -p "${DEST_DIR}"
+
+        if [[ -f "${BUILTIN_LIB_DIR}/libclang_rt.builtins.a" ]]; then
+            cp -v "${BUILTIN_LIB_DIR}/libclang_rt.builtins.a" "${DEST_DIR}/"
+            log "Installed libclang_rt.builtins.a -> ${DEST_DIR}"
+        else
+            log "WARNING: libclang_rt.builtins.a not found in ${BUILTIN_LIB_DIR}"
+        fi
+    done
+done
+
+# ---------------------------------------------------------------------------
+# Copy built libraries to all other architecture versions
+# ---------------------------------------------------------------------------
+log "=== Symlinking builtins to all architecture versions ==="
+
+# Determine the source core (first in BUILD_CORES)
+SOURCE_CORE=$(echo ${BUILD_CORES} | awk '{print $1}')
+log "Using ${SOURCE_CORE} as symlink target for other architectures"
+
+for CORE in ${ALL_CORES}; do
+    # Skip if this core was already built
+    if echo "${BUILD_CORES}" | grep -qw "${CORE}"; then
+        log "Skipping ${CORE} (already built)"
+        continue
+    fi
+
+    log "Symlinking libraries for ${CORE} -> ${SOURCE_CORE}"
+
+    # Symlink individual files (not directories) so a downstream "cp -drfv"
+    # never tries to overwrite an existing real directory with a symlink.
+    LIB_BASE="${FINAL_INSTALL}/target/picolibc/hexagon-unknown-none-elf/lib"
+    SOURCE_DIR="${LIB_BASE}/${SOURCE_CORE}"
+    if [[ -d "${SOURCE_DIR}" ]]; then
+        for VARIANT_SUFFIX in "" "-G0" "-G0-pic"; do
+            SOURCE_VARIANT_DIR="${LIB_BASE}/${SOURCE_CORE}${VARIANT_SUFFIX}"
+            DEST_VARIANT_DIR="${LIB_BASE}/${CORE}${VARIANT_SUFFIX}"
+
+            if [[ ! -d "${SOURCE_VARIANT_DIR}" ]]; then
+                continue
+            fi
+
+            mkdir -p "${DEST_VARIANT_DIR}"
+
+            # Flat layout: variant dirs are siblings under lib/, so the source
+            # is always one level up (../<source-core><suffix>).
+            REL_PREFIX="../${SOURCE_CORE}${VARIANT_SUFFIX}"
+
+            for SRC_FILE in "${SOURCE_VARIANT_DIR}"/*; do
+                [[ -f "${SRC_FILE}" ]] || continue
+                FNAME="$(basename "${SRC_FILE}")"
+                DEST_FILE="${DEST_VARIANT_DIR}/${FNAME}"
+                rm -f "${DEST_FILE}"
+                ln -s "${REL_PREFIX}/${FNAME}" "${DEST_FILE}"
+            done
+        done
+        log "Symlinked builtins (per-file): ${CORE} -> ${SOURCE_CORE}"
+    else
+        log "WARNING: Source directory ${SOURCE_DIR} not found"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Symlink builtins to target/picolibc/hexagon-unknown-h2-elf/
+#
+# hexagon-unknown-h2-elf uses the same builtins as hexagon-unknown-none-elf.
+# Create per-file symlinks pointing back into the none-elf tree.
+# ---------------------------------------------------------------------------
+log "=== Symlinking builtins: picolibc/hexagon-unknown-h2-elf -> picolibc/hexagon-unknown-none-elf ==="
+
+SOURCE_LIB_DIR="${FINAL_INSTALL}/target/picolibc/hexagon-unknown-none-elf/lib"
+DEST_LIB_DIR="${FINAL_INSTALL}/target/picolibc/hexagon-unknown-h2-elf/lib"
+
+if [[ -d "${SOURCE_LIB_DIR}" ]]; then
+    for CORE_DIR in "${SOURCE_LIB_DIR}"/*/; do
+        CORE_NAME="$(basename "${CORE_DIR}")"
+        SOURCE_VARIANT_DIR="${SOURCE_LIB_DIR}/${CORE_NAME}"
+        DEST_VARIANT_DIR="${DEST_LIB_DIR}/${CORE_NAME}"
+
+        if [[ ! -d "${SOURCE_VARIANT_DIR}" ]]; then
+            continue
+        fi
+
+        mkdir -p "${DEST_VARIANT_DIR}"
+
+        # Flat layout: <core-name> already carries any -G0/-G0-pic suffix, so
+        # from h2-elf/lib/<core-name>/ the none-elf sibling tree is three
+        # levels up (../../../hexagon-unknown-none-elf/lib/<core-name>).
+        REL_PREFIX="../../../hexagon-unknown-none-elf/lib/${CORE_NAME}"
+
+        for SRC_FILE in "${SOURCE_VARIANT_DIR}"/*; do
+            [[ -f "${SRC_FILE}" || -L "${SRC_FILE}" ]] || continue
+            FNAME="$(basename "${SRC_FILE}")"
+            DEST_FILE="${DEST_VARIANT_DIR}/${FNAME}"
+            rm -f "${DEST_FILE}"
+            ln -s "${REL_PREFIX}/${FNAME}" "${DEST_FILE}"
+        done
+    done
+    log "Symlinked builtins (per-file): picolibc/hexagon-unknown-h2-elf/lib -> picolibc/hexagon-unknown-none-elf/lib"
+else
+    log "WARNING: Source directory ${SOURCE_LIB_DIR} not found, skipping symlink"
+fi
+
+# ---------------------------------------------------------------------------
+# Copy builtins to target/picolibc/hexagon-unknown-qurt-elf/
+#
+# hexagon-unknown-qurt-elf uses the same builtins as hexagon-unknown-none-elf.
+# Copy the full lib tree so qurt consumers get real files, not symlinks.
+# ---------------------------------------------------------------------------
+log "=== Copying builtins: picolibc/hexagon-unknown-none-elf -> picolibc/hexagon-unknown-qurt-elf ==="
+
+QURT_LIB_DIR="${FINAL_INSTALL}/target/picolibc/hexagon-unknown-qurt-elf/lib"
+
+if [[ -d "${SOURCE_LIB_DIR}" ]]; then
+    mkdir -p "${FINAL_INSTALL}/target/picolibc/hexagon-unknown-qurt-elf"
+    cp -rL "${SOURCE_LIB_DIR}" "${QURT_LIB_DIR}"
+    log "Copied builtins: picolibc/hexagon-unknown-qurt-elf/lib"
+else
+    log "WARNING: Source directory ${SOURCE_LIB_DIR} not found, skipping copy"
+fi
+
+# ---------------------------------------------------------------------------
+# Done
+# ---------------------------------------------------------------------------
+log "=== Build complete ==="
+log "Install tree: ${FINAL_INSTALL}/target/picolibc/hexagon-unknown-none-elf/"
+log "Install tree: ${FINAL_INSTALL}/target/picolibc/hexagon-unknown-h2-elf/"
+log "Install tree: ${FINAL_INSTALL}/target/picolibc/hexagon-unknown-qurt-elf/"

--- a/sysroot-scripts/build_hexagon_h2.sh
+++ b/sysroot-scripts/build_hexagon_h2.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# build_hexagon_h2.sh
+#
+# Builds H2 libraries for Hexagon base architectures (68, 73, 81), fans the
+# artifacts out to all supported architecture versions, then packages them
+# directly into the Tools/target/picolibc/hexagon-unknown-h2-elf install tree.
+#
+# Required environment variables:
+#   TOOLCHAIN    - Path to the installed Hexagon LLVM toolchain
+#                  e.g. /path/to/inst/Tools
+#   H2_SRC       - Path to the H2 source directory (contains Makefile)
+#                  e.g. /path/to/h2
+#   BUILDPATH    - Root directory for all build artifacts
+#                  e.g. /path/to/build
+#   INSTALLPATH  - Root directory where libs/headers are installed
+#                  e.g. /path/to/install
+#
+#
+# Build layout under BUILDPATH:
+#   h2-install-<base>/               (intermediate per-base make install, base = 68|73|81)
+#   h2-install-<version>/            (per-version fanout, e.g. h2-install-v68)
+#
+# Install layout under INSTALLPATH:
+#   Tools/
+#     target/
+#       picolibc/
+#         hexagon-unknown-h2-elf/
+#           bin/<version>/G0/        (binaries, copied from h2-install-<version>/bin)
+#           bin/<version>/           (per-file symlinks -> G0/<file>, for non-G0 applications)
+#           lib/<version>-G0/        (libraries, copied from h2-install-<version>/lib)
+#           lib/<version>/           (per-file symlinks -> ../<version>-G0/<file>, for non-G0 applications)
+#           include/                 (headers, from h2-install-v81/include)
+#
+# Base architecture to version fanout:
+#   68  ->  v68 v69 v71t v71
+#   73  ->  v73 v75 v77 v79
+#   81  ->  v81 v83 v85 v87 v89 v91
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Validate required environment variables
+# ---------------------------------------------------------------------------
+: "${TOOLCHAIN:?'TOOLCHAIN env var is required (path to installed Hexagon LLVM toolchain)'}"
+: "${H2_SRC:?'H2_SRC env var is required (path to H2 source directory)'}"
+: "${BUILDPATH:?'BUILDPATH env var is required (root directory for all build artifacts)'}"
+: "${INSTALLPATH:?'INSTALLPATH env var is required (root directory where libs/headers are installed)'}"
+
+# ---------------------------------------------------------------------------
+# Derived paths
+# ---------------------------------------------------------------------------
+CLANG="${TOOLCHAIN}/bin/hexagon-clang"
+
+# Fall back to plain clang if the hexagon-prefixed variant is absent.
+[[ -x "${CLANG}" ]] || CLANG="${TOOLCHAIN}/bin/clang"
+
+export PATH="${TOOLCHAIN}/bin:${PATH}"
+
+H2_INSTALL_ROOT="${BUILDPATH}/h2-install"
+FINAL_INSTALL="${INSTALLPATH}/Tools"
+
+ELF_TRIPLE="hexagon-unknown-h2-elf"
+OUTDIR="${FINAL_INSTALL}/target/picolibc/${ELF_TRIPLE}"
+
+VERSIONS=(v68 v69 v71t v71 v73 v75 v77 v79 v81 v83 v85 v87 v89 v91)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+log() { echo "[$(date '+%H:%M:%S')] $*"; }
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+require_tool() {
+    command -v "$1" >/dev/null 2>&1 || die "'$1' not found in PATH"
+}
+
+# ---------------------------------------------------------------------------
+# Pre-flight checks
+# ---------------------------------------------------------------------------
+log "=== Pre-flight checks ==="
+require_tool make
+
+[[ -x "${CLANG}" ]]  || die "hexagon-clang/clang not found (tried ${TOOLCHAIN}/bin/hexagon-clang and ${TOOLCHAIN}/bin/clang)"
+[[ -d "${H2_SRC}" ]] || die "H2 source not found at ${H2_SRC}"
+
+log "H2 src:  ${H2_SRC}"
+log "Output:  ${OUTDIR}"
+
+mkdir -p "${H2_INSTALL_ROOT}"
+
+# ---------------------------------------------------------------------------
+# Build H2 for base architectures 68, 73, 81
+# ---------------------------------------------------------------------------
+log "=== Build H2 for base ARCHV 68, 73, 81 ==="
+
+# Clean previous install fanouts to avoid mixing artifacts
+log "Cleaning previous fanout dirs under ${H2_INSTALL_ROOT}"
+rm -rf "${H2_INSTALL_ROOT}"-v*
+
+for base in 68 73 81; do
+    log "== Removing ${BUILDPATH}/build and ${H2_INSTALL_ROOT}-${base}"
+    rm -rf "${BUILDPATH}/build/"
+    rm -rf "${H2_INSTALL_ROOT}-${base}/"
+
+    log "== Building ARCHV=${base}"
+    make -j1 -C "${H2_SRC}" \
+        USE_PKW=0 \
+        ARCHV="${base}" \
+        TARGET=opt \
+        INSTALLPATH="${H2_INSTALL_ROOT}-${base}" \
+        PICOLIBC=1 \
+        NULL_ANGEL_TRAP=1 \
+        JFLAG="-j1"
+done
+
+# ---------------------------------------------------------------------------
+# Fan out per-version copies
+# ---------------------------------------------------------------------------
+log "=== Fanning out per-version install trees ==="
+
+# Base 68 -> v68 v69 v71t v71
+for v in v68 v69 v71t v71; do
+    log "Copying install-68 -> ${H2_INSTALL_ROOT}-${v}"
+    rm -rf "${H2_INSTALL_ROOT}-${v}"
+    cp -a "${H2_INSTALL_ROOT}-68" "${H2_INSTALL_ROOT}-${v}"
+done
+
+# Base 73 -> v73 v75 v77 v79
+for v in v73 v75 v77 v79; do
+    log "Copying install-73 -> ${H2_INSTALL_ROOT}-${v}"
+    rm -rf "${H2_INSTALL_ROOT}-${v}"
+    cp -a "${H2_INSTALL_ROOT}-73" "${H2_INSTALL_ROOT}-${v}"
+done
+
+# Base 81 -> v81 v83 v85 v87 v89 v91
+for v in v81 v83 v85 v87 v89 v91; do
+    log "Copying install-81 -> ${H2_INSTALL_ROOT}-${v}"
+    rm -rf "${H2_INSTALL_ROOT}-${v}"
+    cp -a "${H2_INSTALL_ROOT}-81" "${H2_INSTALL_ROOT}-${v}"
+done
+
+log "=== Build & fan-out complete ==="
+
+# ---------------------------------------------------------------------------
+# Package artifacts into the Tools install tree
+# ---------------------------------------------------------------------------
+log "=== Copying H2 artifacts into ${OUTDIR} ==="
+
+mkdir -p "${OUTDIR}"
+
+# 1) Copy bin into target/picolibc/<elf>/bin/<version>/G0
+log "== Copying bin to ${ELF_TRIPLE}/bin/<version>/G0 =="
+for v in "${VERSIONS[@]}"; do
+    src="${H2_INSTALL_ROOT}-${v}/bin"
+    dst="${OUTDIR}/bin/${v}/G0"
+    mkdir -p "${dst}"
+    if [[ -d "${src}" ]]; then
+        cp -a "${src}/." "${dst}/"
+    fi
+done
+
+# 1b) Symlink non-G0 -> G0 for bin (files placed directly under bin/<version>/)
+log "== Symlinking bin non-G0 -> G0 for ${ELF_TRIPLE} =="
+for v in "${VERSIONS[@]}"; do
+    src="${OUTDIR}/bin/${v}/G0"
+    dst="${OUTDIR}/bin/${v}"
+    if [[ -d "${src}" ]]; then
+        for f in "${src}"/*; do
+            [[ -e "${f}" || -L "${f}" ]] || continue
+            fname="$(basename "${f}")"
+            rm -f "${dst}/${fname}"
+            ln -s "G0/${fname}" "${dst}/${fname}"
+        done
+    fi
+done
+
+# 2) Copy libs into target/picolibc/<elf>/lib/<version>-G0
+log "== Copying libs to ${ELF_TRIPLE}/lib/<version>-G0 =="
+for v in "${VERSIONS[@]}"; do
+    src="${H2_INSTALL_ROOT}-${v}/lib"
+    dst="${OUTDIR}/lib/${v}-G0"
+    mkdir -p "${dst}"
+    if [[ -d "${src}" ]]; then
+        cp -a "${src}/." "${dst}/"
+    fi
+done
+
+# 2b) Symlink non-G0 -> G0 for lib (files placed directly under lib/<version>/)
+#     Flat layout: lib/<version> and lib/<version>-G0 are siblings, so the
+#     link target is ../<version>-G0/<file>.
+log "== Symlinking lib non-G0 -> G0 for ${ELF_TRIPLE} =="
+for v in "${VERSIONS[@]}"; do
+    src="${OUTDIR}/lib/${v}-G0"
+    dst="${OUTDIR}/lib/${v}"
+    if [[ -d "${src}" ]]; then
+        mkdir -p "${dst}"
+        for f in "${src}"/*; do
+            [[ -e "${f}" || -L "${f}" ]] || continue
+            fname="$(basename "${f}")"
+            rm -f "${dst}/${fname}"
+            ln -s "../${v}-G0/${fname}" "${dst}/${fname}"
+        done
+    fi
+done
+
+# 3) Copy includes into target/picolibc/<elf>/include/ (use v81 as the header source)
+log "== Copying includes to ${ELF_TRIPLE}/include =="
+inc_src="${H2_INSTALL_ROOT}-v81/include"
+inc_dst="${OUTDIR}/include"
+mkdir -p "${inc_dst}"
+if [[ -d "${inc_src}" ]]; then
+    cp -a "${inc_src}/." "${inc_dst}/"
+fi
+
+# ---------------------------------------------------------------------------
+# Install clang config file
+# ---------------------------------------------------------------------------
+log "=== Installing h2-picolibc.cfg ==="
+mkdir -p "${FINAL_INSTALL}/bin"
+cat > "${FINAL_INSTALL}/bin/h2-picolibc.cfg" <<'EOF'
+--target=hexagon-unknown-h2-elf \
+--cstdlib=picolibc \
+$-Wl,--undefined=__retarget_lock_init \
+$-Wl,-l:liblocks.a \
+$-Wl,--section-start=.start=0x2000000 \
+$-Wl,-T,<CFGDIR>/../templates/staticExecutable/static-executable-h2-picolibc.lcs.template
+EOF
+log "Installed cfg -> ${FINAL_INSTALL}/bin/h2-picolibc.cfg"
+
+# ---------------------------------------------------------------------------
+# Done
+# ---------------------------------------------------------------------------
+log "=== Build complete ==="
+log "Install tree: ${OUTDIR}/"

--- a/sysroot-scripts/build_hexagon_picolibc.sh
+++ b/sysroot-scripts/build_hexagon_picolibc.sh
@@ -1,0 +1,472 @@
+#!/usr/bin/env bash
+# build_hexagon_picolibc.sh
+#
+# Builds picolibc for all Hexagon cores (G0, non-G0, and G0+PIC) and installs
+# into Tools/target/picolibc/hexagon-unknown-{none,h2,qurt}-elf structure.
+# The G0+PIC variant is built with the local-dynamic TLS model
+# (-Dtls-model=local-dynamic) for use in shared-library contexts.
+#
+# Required environment variables:
+#   TOOLCHAIN    - Path to the installed Hexagon LLVM toolchain
+#                  e.g. /path/to/inst/Tools
+#   PICOLIBC_SRC - Path to the picolibc source directory (contains meson.build)
+#                  e.g. /path/to/picolibc
+#   BUILDPATH    - Root directory for all build artifacts
+#                  e.g. /path/to/build
+#   INSTALLPATH  - Root directory where libs/headers are installed
+#                  e.g. /path/to/install
+#
+# Optional environment variables:
+#   BUILD_CORES    - Space-separated list of Hexagon arch versions to actually build
+#                    (default: "v68")
+#   ALL_CORES      - Space-separated list of all Hexagon arch versions to install for
+#                    (default: "v68 v69 v71 v71t v73 v75 v77 v79 v81 v83 v85 v87 v89 v91")
+#   BUILD_VARIANTS - Space-separated list of variants to build: non-G0, G0, G0-pic
+#                    (default: "non-G0 G0 G0-pic")
+#   TEST           - Set to 1 to enable tests (default: 0)
+#   MESON          - Path to the meson executable (default: meson)
+#   NINJA          - Path to the ninja executable (default: ninja)
+#   JOBS           - Parallel jobs for ninja (default: number of CPU cores)
+#
+# Build layout under BUILDPATH:
+#   picolibc-build/
+#     build-picolibc-<core>/           (meson build dir, non-G0)
+#     build-picolibc-<core>-G0/        (meson build dir, G0)
+#     build-picolibc-<core>-G0-pic/    (meson build dir, G0 + PIC)
+#   picolibc-install/
+#     <core>/                          (intermediate install, non-G0)
+#     <core>-G0/                       (intermediate install, G0)
+#     <core>-G0-pic/                   (intermediate install, G0 + PIC)
+#
+# Install layout under INSTALLPATH (flat variant directories):
+#   Tools/
+#     target/
+#       picolibc/
+#         hexagon-unknown-none-elf/
+#           include/
+#           lib/<core>/
+#             libc.a  libm.a  ...      (non-G0, built)
+#           lib/<core>-G0/
+#             libc.a  libm.a  ...      (G0, built)
+#           lib/<core>-G0-pic/
+#             libc.a  libm.a  ...      (G0 + PIC, local-dynamic TLS, built)
+#           lib/<other-core>[-G0[-pic]]/  (per-file symlinks into lib/<core>[-G0[-pic]]/)
+#         hexagon-unknown-h2-elf/      (per-file symlinks into hexagon-unknown-none-elf)
+#         hexagon-unknown-qurt-elf/    (copy of hexagon-unknown-none-elf)
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Validate required environment variables
+# ---------------------------------------------------------------------------
+: "${TOOLCHAIN:?'TOOLCHAIN env var is required (path to installed Hexagon LLVM toolchain)'}"
+: "${PICOLIBC_SRC:?'PICOLIBC_SRC env var is required (path to picolibc source directory)'}"
+: "${BUILDPATH:?'BUILDPATH env var is required (root directory for all build artifacts)'}"
+: "${INSTALLPATH:?'INSTALLPATH env var is required (root directory where libs/headers are installed)'}"
+
+# ---------------------------------------------------------------------------
+# Defaults for optional variables
+# ---------------------------------------------------------------------------
+BUILD_CORES="${BUILD_CORES:-v68}"
+ALL_CORES="${ALL_CORES:-v68 v69 v71 v71t v73 v75 v77 v79 v81 v83 v85 v87 v89 v91}"
+BUILD_VARIANTS="${BUILD_VARIANTS:-non-G0 G0 G0-pic}"
+ENABLE_TESTS="${TEST:-0}"
+MESON="${MESON:-meson}"
+NINJA="${NINJA:-ninja}"
+JOBS="${JOBS:-$(nproc)}"
+
+# ---------------------------------------------------------------------------
+# Cross-file generation settings
+# ---------------------------------------------------------------------------
+CROSS_TARGET="hexagon-unknown-none-elf"
+CROSS_SYSTEM="linux"
+CROSS_CPU_FAMILY="hexagon"
+CROSS_CPU="hexagon"
+CROSS_ENDIAN="little"
+
+# Flags common to all variants
+CROSS_COMMON_CFLAGS=(
+    "--target=${CROSS_TARGET}"
+    "--cstdlib=picolibc"
+    "-nostdlib"
+    "-ffunction-sections"
+    "-fdata-sections"
+    "-fvisibility=hidden"
+)
+CROSS_COMMON_LINK_ARGS=(
+    "--target=${CROSS_TARGET}"
+    "--cstdlib=picolibc"
+    "-nostdlib"
+)
+
+# Per-variant extra c_args (prepended before common flags)
+# non-G0: no small-data, no PIC
+CROSS_NON_G0_EXTRA_CFLAGS=( "-fno-pic" "-fno-PIE" "-static" )
+
+# G0: small-data model, no PIC
+CROSS_G0_EXTRA_CFLAGS=( "-fno-pic" "-fno-PIE" "-static" "-G0" )
+
+# G0-pic: small-data model, PIC, local-dynamic TLS
+CROSS_G0_PIC_EXTRA_CFLAGS=( "-fPIC" "-static" "-G0" )
+
+# [properties] values (identical across all variants)
+CROSS_LIBRT="-lclang_rt.builtins"
+CROSS_LINK_SPEC="--build-id=none"
+CROSS_SDATA_ALIGNMENT="64"
+CROSS_DEFAULT_RAM_ADDR="0x00500000"
+CROSS_DEFAULT_RAM_SIZE="0x00800000"
+CROSS_DEFAULT_FLASH_ADDR="0x00100000"
+CROSS_DEFAULT_FLASH_SIZE="0x00400000"
+
+# ---------------------------------------------------------------------------
+# generate_cross_file CORE VARIANT
+#   Emits a Meson cross file to stdout.
+#   VARIANT - one of: non-G0  G0  G0-pic
+# ---------------------------------------------------------------------------
+generate_cross_file() {
+    local CORE="$1"
+    local VARIANT="$2"
+    local -a CFLAGS=()
+
+    case "${VARIANT}" in
+        non-G0)
+            CFLAGS+=( "${CROSS_NON_G0_EXTRA_CFLAGS[@]}" )
+            ;;
+        G0)
+            CFLAGS+=( "${CROSS_G0_EXTRA_CFLAGS[@]}" )
+            ;;
+        G0-pic)
+            CFLAGS+=( "${CROSS_G0_PIC_EXTRA_CFLAGS[@]}" )
+            ;;
+        *)
+            die "generate_cross_file: unknown variant '${VARIANT}'"
+            ;;
+    esac
+
+    CFLAGS+=( "-m${CORE}" "${CROSS_COMMON_CFLAGS[@]}" )
+
+    local C_ARGS_STR=""
+    local FLAG
+    for FLAG in "${CFLAGS[@]}"; do
+        C_ARGS_STR+="'${FLAG}', "
+    done
+    C_ARGS_STR="[ ${C_ARGS_STR%, } ]"
+
+    local C_LINK_ARGS_STR=""
+    for FLAG in "${CROSS_COMMON_LINK_ARGS[@]}"; do
+        C_LINK_ARGS_STR+="'${FLAG}', "
+    done
+    C_LINK_ARGS_STR="[ ${C_LINK_ARGS_STR%, } ]"
+
+    cat <<EOF
+[binaries]
+c = '${MESON_C}'
+cpp = '${MESON_CXX}'
+c_ld = 'eld'
+ar = 'hexagon-ar'
+as = 'as'
+nm = 'hexagon-nm'
+strip = 'hexagon-strip'
+objcopy = 'hexagon-llvm-objcopy'
+# only needed to run tests
+exe_wrapper = ['env', 'run-hexagon']
+
+[host_machine]
+system = '${CROSS_SYSTEM}'
+cpu_family = '${CROSS_CPU_FAMILY}'
+cpu = '${CROSS_CPU}'
+endian = '${CROSS_ENDIAN}'
+
+[built-in options]
+c_args = ${C_ARGS_STR}
+c_link_args = ${C_LINK_ARGS_STR}
+cpp_args = ${C_ARGS_STR}
+cpp_link_args = ${C_LINK_ARGS_STR}
+
+[properties]
+librt = '${CROSS_LIBRT}'
+skip_sanity_check = true
+needs_exe_wrapper = true
+link_spec = '${CROSS_LINK_SPEC}'
+sdata_alignment = '${CROSS_SDATA_ALIGNMENT}'
+default_ram_addr   = '${CROSS_DEFAULT_RAM_ADDR}'
+default_ram_size   = '${CROSS_DEFAULT_RAM_SIZE}'
+default_flash_addr = '${CROSS_DEFAULT_FLASH_ADDR}'
+default_flash_size = '${CROSS_DEFAULT_FLASH_SIZE}'
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Derived paths
+# ---------------------------------------------------------------------------
+CLANG="${TOOLCHAIN}/bin/hexagon-clang"
+CLANGXX="${TOOLCHAIN}/bin/hexagon-clang++"
+
+# Fall back to plain clang/clang++ if hexagon-prefixed variants are absent.
+# MESON_C / MESON_CXX carry the (bare) tool names emitted into the Meson
+# cross-file; PATH is prepended with ${TOOLCHAIN}/bin below so bare names
+# resolve to the correct toolchain binary.
+MESON_C="hexagon-clang"
+MESON_CXX="hexagon-clang++"
+if [[ ! -x "${CLANG}" ]]; then
+    CLANG="${TOOLCHAIN}/bin/clang"
+    MESON_C="clang"
+fi
+if [[ ! -x "${CLANGXX}" ]]; then
+    CLANGXX="${TOOLCHAIN}/bin/clang++"
+    MESON_CXX="clang++"
+fi
+
+export PATH="${TOOLCHAIN}/bin:${PATH}"
+
+PICOLIBC_BUILD_ROOT="${BUILDPATH}/picolibc-build"
+PICOLIBC_INSTALL_ROOT="${BUILDPATH}/picolibc-install"
+
+FINAL_INSTALL="${INSTALLPATH}/Tools"
+OUTDIR="${FINAL_INSTALL}/target/picolibc/hexagon-unknown-none-elf"
+H2_OUTDIR="${FINAL_INSTALL}/target/picolibc/hexagon-unknown-h2-elf"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+log() { echo "[$(date '+%H:%M:%S')] $*"; }
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+require_tool() {
+    command -v "$1" >/dev/null 2>&1 || die "'$1' not found in PATH"
+}
+
+# ---------------------------------------------------------------------------
+# Pre-flight checks
+# ---------------------------------------------------------------------------
+log "=== Pre-flight checks ==="
+require_tool "${MESON}"
+require_tool "${NINJA}"
+require_tool git
+
+[[ -x "${CLANG}" ]]        || die "hexagon-clang/clang not found (tried ${TOOLCHAIN}/bin/hexagon-clang and ${TOOLCHAIN}/bin/clang)"
+[[ -x "${CLANGXX}" ]]      || die "hexagon-clang++/clang++ not found (tried ${TOOLCHAIN}/bin/hexagon-clang++ and ${TOOLCHAIN}/bin/clang++)"
+[[ -d "${PICOLIBC_SRC}" ]] || die "picolibc source not found at ${PICOLIBC_SRC}"
+
+if [[ "${ENABLE_TESTS}" == "1" ]]; then
+    TEST_FLAGS="-Dtests=true -Dtests-enable-posix-io=true -Dtest-stdin=true"
+    log "Tests: ENABLED"
+else
+    TEST_FLAGS="-Dtests=false"
+    log "Tests: DISABLED"
+fi
+
+log "Picolibc src: ${PICOLIBC_SRC}"
+log "Building for cores: ${BUILD_CORES}"
+log "Building variants:  ${BUILD_VARIANTS}"
+log "Will symlink to all cores: ${ALL_CORES}"
+log "Output:  ${OUTDIR}"
+
+mkdir -p "${PICOLIBC_BUILD_ROOT}" "${PICOLIBC_INSTALL_ROOT}" "${OUTDIR}/include" "${OUTDIR}/lib"
+
+# ---------------------------------------------------------------------------
+# Build picolibc (non-G0, G0, and G0+PIC — one build per core per variant)
+# ---------------------------------------------------------------------------
+log "=== Building picolibc ==="
+
+TEST_FAILED=0
+
+for CORE in ${BUILD_CORES}; do
+    for VARIANT in ${BUILD_VARIANTS}; do
+        case "${VARIANT}" in
+            non-G0)
+                VARIANT_SUFFIX=""
+                DEST_SUFFIX=""
+                MESON_EXTRA_OPTS=""
+                ;;
+            G0)
+                VARIANT_SUFFIX="-G0"
+                DEST_SUFFIX="-G0"
+                MESON_EXTRA_OPTS=""
+                ;;
+            G0-pic)
+                VARIANT_SUFFIX="-G0-pic"
+                DEST_SUFFIX="-G0-pic"
+                MESON_EXTRA_OPTS="-Dtls-model=local-dynamic"
+                ;;
+        esac
+
+        log "--- picolibc: ${CORE}${VARIANT_SUFFIX} ---"
+
+        CROSS_FILE="${PICOLIBC_BUILD_ROOT}/cross-clang-hexagon-${CORE}${VARIANT_SUFFIX}.txt"
+        generate_cross_file "${CORE}" "${VARIANT}" > "${CROSS_FILE}"
+        log "Generated cross file: ${CROSS_FILE}"
+        log "--- cross file contents ---"
+        cat "${CROSS_FILE}"
+        log "--- end cross file ---"
+
+        BUILD_DIR="${PICOLIBC_BUILD_ROOT}/build-picolibc-${CORE}${VARIANT_SUFFIX}"
+        INSTALL_DIR="${PICOLIBC_INSTALL_ROOT}/${CORE}${VARIANT_SUFFIX}"
+        mkdir -p "${BUILD_DIR}" "${INSTALL_DIR}"
+
+        "${MESON}" setup "${BUILD_DIR}" "${PICOLIBC_SRC}" \
+            --buildtype=release \
+            --cross-file="${CROSS_FILE}" \
+            --prefix="${INSTALL_DIR}" \
+            ${TEST_FLAGS} \
+            ${MESON_EXTRA_OPTS} \
+            -Dstdio-locking=true \
+            -Dstdio-exit-flush=true \
+            -Dmultilib=false \
+            -Dposix-console=true
+
+        "${NINJA}" -C "${BUILD_DIR}" -j"${JOBS}"
+        "${NINJA}" -C "${BUILD_DIR}" install
+
+        if [[ "${ENABLE_TESTS}" == "1" ]]; then
+            log "--- running tests: ${CORE}${VARIANT_SUFFIX} ---"
+            "${MESON}" test -C "${BUILD_DIR}" -t 20 \
+                || { log "ERROR: tests failed for ${CORE}${VARIANT_SUFFIX}"; TEST_FAILED=1; }
+        fi
+
+        DEST_LIB="${OUTDIR}/lib/${CORE}${DEST_SUFFIX}"
+        mkdir -p "${DEST_LIB}"
+
+        if [[ -d "${INSTALL_DIR}/lib" ]]; then
+            cp -a "${INSTALL_DIR}/lib/." "${DEST_LIB}/"
+        else
+            log "WARNING: no lib dir found at ${INSTALL_DIR}/lib"
+        fi
+        log "Installed picolibc for ${CORE}${VARIANT_SUFFIX} -> ${DEST_LIB}"
+    done
+done
+
+# ---------------------------------------------------------------------------
+# Copy headers (use G0 of first core; identical across all cores and variants)
+# ---------------------------------------------------------------------------
+FIRST_CORE="${BUILD_CORES%% *}"
+SRC_INC="${PICOLIBC_INSTALL_ROOT}/${FIRST_CORE}-G0/include"
+if [[ ! -d "${SRC_INC}" ]]; then
+    SRC_INC="$(find "${PICOLIBC_INSTALL_ROOT}" -maxdepth 3 -type d -name include | head -n1 || true)"
+fi
+[[ -d "${SRC_INC}" ]] || die "could not find installed headers under ${PICOLIBC_INSTALL_ROOT}"
+cp -a "${SRC_INC}/." "${OUTDIR}/include/"
+log "Installed headers -> ${OUTDIR}/include"
+
+# ---------------------------------------------------------------------------
+# Symlink built libraries to all other architecture versions
+#
+# Per-file symlinks (not directory symlinks) so downstream "cp -drfv" can
+# descend into real directories without "cannot overwrite directory" errors.
+#
+# Flat layout: variant dirs are siblings under lib/, so relative path from
+# lib/<core><suffix>/ back to lib/<source><suffix>/ is always one level up:
+#   lib/<core>/          -> ../<source>/
+#   lib/<core>-G0/       -> ../<source>-G0/
+#   lib/<core>-G0-pic/   -> ../<source>-G0-pic/
+# ---------------------------------------------------------------------------
+log "=== Symlinking picolibc to all architecture versions ==="
+
+SOURCE_CORE=$(echo ${BUILD_CORES} | awk '{print $1}')
+log "Using ${SOURCE_CORE} as source for symlinking to other architectures"
+
+for CORE in ${ALL_CORES}; do
+    if echo "${BUILD_CORES}" | grep -qw "${CORE}"; then
+        log "Skipping ${CORE} (already built)"
+        continue
+    fi
+
+    log "Symlinking libraries for ${CORE} from ${SOURCE_CORE}"
+
+    for VARIANT_SUFFIX in "" "-G0" "-G0-pic"; do
+        REL_PREFIX="../"
+
+        SRC_DIR="${OUTDIR}/lib/${SOURCE_CORE}${VARIANT_SUFFIX}"
+        DST_DIR="${OUTDIR}/lib/${CORE}${VARIANT_SUFFIX}"
+
+        if [[ ! -d "${SRC_DIR}" ]]; then
+            log "WARNING: source directory ${SRC_DIR} not found, skipping"
+            continue
+        fi
+
+        mkdir -p "${DST_DIR}"
+
+        for SRC_FILE in "${SRC_DIR}"/*; do
+            [[ -e "${SRC_FILE}" || -L "${SRC_FILE}" ]] || continue
+            FNAME="$(basename "${SRC_FILE}")"
+            # Skip real subdirectories; nothing nested is expected in flat layout
+            [[ -d "${SRC_FILE}" && ! -L "${SRC_FILE}" ]] && continue
+            ln -sf "${REL_PREFIX}${SOURCE_CORE}${VARIANT_SUFFIX}/${FNAME}" \
+                "${DST_DIR}/${FNAME}"
+        done
+
+        log "Symlinked ${VARIANT_SUFFIX:-non-G0} picolibc: ${SOURCE_CORE} -> ${CORE}"
+    done
+done
+
+# ---------------------------------------------------------------------------
+# Symlink hexagon-unknown-none-elf -> hexagon-unknown-h2-elf
+#
+# H2_OUTDIR is a sibling of OUTDIR under target/picolibc/. With the flat
+# layout each <core><suffix> is a direct child of lib/, so relative paths
+# from H2_OUTDIR/lib/<core><suffix>/ back to OUTDIR/lib/<core><suffix>/ are
+# always three levels up:
+#   lib/<core>/          -> ../../../hexagon-unknown-none-elf/lib/<core>/
+#   lib/<core>-G0/       -> ../../../hexagon-unknown-none-elf/lib/<core>-G0/
+#   lib/<core>-G0-pic/   -> ../../../hexagon-unknown-none-elf/lib/<core>-G0-pic/
+# ---------------------------------------------------------------------------
+NONE_TRIPLE="hexagon-unknown-none-elf"
+
+log "Symlinking ${OUTDIR} -> ${H2_OUTDIR}"
+rm -rf "${H2_OUTDIR}"
+mkdir -p "${H2_OUTDIR}/include" "${H2_OUTDIR}/lib"
+
+for SRC_FILE in "${OUTDIR}/include"/*; do
+    [[ -e "${SRC_FILE}" || -L "${SRC_FILE}" ]] || continue
+    FNAME="$(basename "${SRC_FILE}")"
+    ln -sf "../../${NONE_TRIPLE}/include/${FNAME}" "${H2_OUTDIR}/include/${FNAME}"
+done
+log "Symlinked headers -> ${H2_OUTDIR}/include"
+
+for CORE_DIR in "${OUTDIR}/lib"/*/; do
+    [[ -d "${CORE_DIR}" ]] || continue
+    CORE="$(basename "${CORE_DIR}")"
+
+    SRC_DIR="${OUTDIR}/lib/${CORE}"
+    DST_DIR="${H2_OUTDIR}/lib/${CORE}"
+
+    [[ -d "${SRC_DIR}" ]] || continue
+    mkdir -p "${DST_DIR}"
+
+    # Flat layout: <core> already carries any -G0/-G0-pic suffix.
+    REL_PREFIX="../../../"
+
+    for SRC_FILE in "${SRC_DIR}"/*; do
+        [[ -e "${SRC_FILE}" || -L "${SRC_FILE}" ]] || continue
+        FNAME="$(basename "${SRC_FILE}")"
+        [[ -d "${SRC_FILE}" && ! -L "${SRC_FILE}" ]] && continue
+        ln -sf "${REL_PREFIX}${NONE_TRIPLE}/lib/${CORE}/${FNAME}" \
+            "${DST_DIR}/${FNAME}"
+    done
+done
+log "Symlinked H2 artifacts -> ${H2_OUTDIR}"
+
+# ---------------------------------------------------------------------------
+# Copy hexagon-unknown-none-elf -> hexagon-unknown-qurt-elf
+#
+# Artifacts are identical to none-elf; only the --target= triple differs and
+# has no effect on object code, so we copy rather than rebuild.
+# ---------------------------------------------------------------------------
+QURT_OUTDIR="${FINAL_INSTALL}/target/picolibc/hexagon-unknown-qurt-elf"
+
+log "Copying ${OUTDIR} -> ${QURT_OUTDIR}"
+rm -rf "${QURT_OUTDIR}"
+cp -a "${OUTDIR}" "${QURT_OUTDIR}"
+log "Copied artifacts -> ${QURT_OUTDIR}"
+
+# ---------------------------------------------------------------------------
+# Done
+# ---------------------------------------------------------------------------
+log "=== Build complete ==="
+log "Install tree: ${FINAL_INSTALL}/target/picolibc/hexagon-unknown-none-elf/"
+log "Install tree: ${FINAL_INSTALL}/target/picolibc/hexagon-unknown-h2-elf/"
+log "Install tree: ${FINAL_INSTALL}/target/picolibc/hexagon-unknown-qurt-elf/"
+
+if [[ "${ENABLE_TESTS}" == "1" && "${TEST_FAILED}" -ne 0 ]]; then
+    die "one or more test variants failed — see above for details"
+fi

--- a/sysroot-scripts/build_hexagon_runtimes.sh
+++ b/sysroot-scripts/build_hexagon_runtimes.sh
@@ -1,0 +1,339 @@
+#!/usr/bin/env bash
+# build_runtimes.sh
+#
+# Builds runtimes (libunwind, libcxxabi, libcxx) for Hexagon targets.
+# Supports multiple triples with different configurations.
+#
+# Required environment variables:
+#   TOOLCHAIN    - Path to the installed Hexagon LLVM toolchain
+#                  e.g. /path/to/inst/Tools
+#   SOURCECODE   - Path to the llvm-top source directory
+#                  e.g. /path/to/build/llvm-top
+#   BUILDPATH    - Root directory for all build artifacts
+#                  e.g. /path/to/build
+#   INSTALLPATH  - Root directory where libs/headers are installed
+#                  e.g. /path/to/install
+#
+# Optional environment variables:
+#   BUILD_CORES  - Space-separated list of Hexagon arch versions to actually build
+#                  (default: "v68")
+#   ALL_CORES    - Space-separated list of all Hexagon arch versions to install for
+#                  (default: "v68 v69 v71 v71t v73 v75 v77 v79 v81 v83 v85 v87 v89 v91")
+#   NINJA        - Path to the ninja executable (default: ninja)
+#   JOBS         - Parallel jobs for ninja (default: number of CPU cores)
+#
+# Build layout under BUILDPATH:
+#   runtimes/
+#     build-<build-prefix>-<core>/            (cmake build dir, non-G0)
+#     build-<build-prefix>-<core>-G0/         (cmake build dir, G0)
+#     build-<build-prefix>-<core>-G0-pic/     (cmake build dir, G0 + PIC)
+#     install/<build-prefix>-<core>/          (intermediate install, non-G0)
+#     install/<build-prefix>-<core>-G0/       (intermediate install, G0)
+#     install/<build-prefix>-<core>-G0-pic/   (intermediate install, G0 + PIC)
+#
+# Install layout under INSTALLPATH (flat variant directories):
+#   target/
+#     <triple>/
+#       include/
+#       lib/<core>/
+#         libunwind.a                  (non-G0, built)
+#         libc++abi.a
+#         libc++.a
+#       lib/<core>-G0/
+#         libunwind.a                  (G0, built)
+#         libc++abi.a
+#         libc++.a
+#       lib/<core>-G0-pic/
+#         libunwind.a                  (G0 + PIC, built)
+#         libc++abi.a
+#         libc++.a
+#       lib/<other-core>/              (real dir; each file symlinks into lib/<core>/)
+#         libunwind.a -> ../<core>/libunwind.a
+#         libc++abi.a -> ../<core>/libc++abi.a
+#         libc++.a    -> ../<core>/libc++.a
+#       lib/<other-core>-G0/
+#         libunwind.a -> ../<core>-G0/libunwind.a  (etc.)
+#       lib/<other-core>-G0-pic/
+#         libunwind.a -> ../<core>-G0-pic/libunwind.a  (etc.)
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Validate required environment variables
+# ---------------------------------------------------------------------------
+: "${TOOLCHAIN:?'TOOLCHAIN env var is required (path to installed Hexagon LLVM toolchain)'}"
+: "${SOURCECODE:?'SOURCECODE env var is required (path to llvm-top source directory)'}"
+: "${BUILDPATH:?'BUILDPATH env var is required (root directory for all build artifacts)'}"
+: "${INSTALLPATH:?'INSTALLPATH env var is required (root directory where libs/headers are installed)'}"
+
+# ---------------------------------------------------------------------------
+# Defaults for optional variables
+# ---------------------------------------------------------------------------
+BUILD_CORES="${BUILD_CORES:-v68}"
+ALL_CORES="${ALL_CORES:-v68 v69 v71 v71t v73 v75 v77 v79 v81 v83 v85 v87 v89 v91}"
+NINJA="${NINJA:-ninja}"
+JOBS="${JOBS:-$(nproc)}"
+
+# ---------------------------------------------------------------------------
+# Derived paths
+# ---------------------------------------------------------------------------
+CLANG="${TOOLCHAIN}/bin/hexagon-clang"
+CLANGXX="${TOOLCHAIN}/bin/hexagon-clang++"
+
+# Fall back to plain clang/clang++ if hexagon-prefixed variants are absent.
+[[ -x "${CLANG}"   ]] || CLANG="${TOOLCHAIN}/bin/clang"
+[[ -x "${CLANGXX}" ]] || CLANGXX="${TOOLCHAIN}/bin/clang++"
+
+RUNTIMES_SRC="${SOURCECODE}/runtimes"
+
+RUNTIMES_BUILD_ROOT="${BUILDPATH}/runtimes"
+RUNTIMES_INSTALL_ROOT="${BUILDPATH}/runtimes/install"
+
+FINAL_INSTALL="${INSTALLPATH}/Tools"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+log() { echo "[$(date '+%H:%M:%S')] $*"; }
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+require_tool() {
+    command -v "$1" >/dev/null 2>&1 || die "'$1' not found in PATH"
+}
+
+# ---------------------------------------------------------------------------
+# build_runtimes_for_triple
+#
+# Builds runtimes for a specific triple with custom configuration.
+#
+# Arguments:
+#   $1  TRIPLE                  - Target triple (e.g., hexagon-unknown-none-elf)
+#   $2  BUILD_PREFIX            - Prefix for build directories (e.g., hexagon)
+#   $3  EXTRA_C_FLAGS           - Additional C compiler flags
+#   $4  EXTRA_CXX_FLAGS         - Additional C++ compiler flags
+#   $5  ENABLE_THREADS          - ON or OFF
+#   $6  USE_LIBC                - Libc to use (e.g., picolibc)
+#   $7  MONOTONIC_CLOCK         - ON or OFF
+#   $8  WIDE_CHARACTERS         - ON or OFF
+#   $9  LOCALIZATION            - ON or OFF
+#   $10 EXTRA_SITE_DEFINES      - Semicolon-separated list of NAME or NAME=VALUE defines
+#                                 baked into the installed __config_site header
+#   $11 INSTALL_PREFIX_OVERRIDE - Optional override for the install destination base
+#                                 (default: ${FINAL_INSTALL}/target/${TRIPLE})
+#                                 Use to install into e.g. target/picolibc/<triple>
+# ---------------------------------------------------------------------------
+build_runtimes_for_triple() {
+    local TRIPLE="$1"
+    local BUILD_PREFIX="$2"
+    local EXTRA_C_FLAGS="$3"
+    local EXTRA_CXX_FLAGS="$4"
+    local ENABLE_THREADS="$5"
+    local USE_LIBC="$6"
+    local MONOTONIC_CLOCK="$7"
+    local WIDE_CHARACTERS="$8"
+    local LOCALIZATION="$9"
+    local EXTRA_SITE_DEFINES="${10:-}"
+    local INSTALL_PREFIX_OVERRIDE="${11:-}"
+    local DEST_BASE="${INSTALL_PREFIX_OVERRIDE:-${FINAL_INSTALL}/target/${TRIPLE}}"
+
+    log "=== Building runtimes for ${TRIPLE} ==="
+    log "Building for cores: ${BUILD_CORES}"
+    log "Will copy to all cores: ${ALL_CORES}"
+
+    for CORE in ${BUILD_CORES}; do
+        for VARIANT in "non-G0" "G0" "G0-pic"; do
+            if [[ "${VARIANT}" == "G0" ]]; then
+                VARIANT_SUFFIX="-G0"
+                G0_FLAG="-G0"
+                DEST_SUFFIX="-G0"
+                PIC_FLAG=""
+                EXTRA_FLAGS="-O3 -ffunction-sections -fdata-sections"
+            elif [[ "${VARIANT}" == "G0-pic" ]]; then
+                VARIANT_SUFFIX="-G0-pic"
+                G0_FLAG="-G0"
+                DEST_SUFFIX="-G0-pic"
+                PIC_FLAG="-fPIC"
+                EXTRA_FLAGS="-O3 -ffunction-sections -fdata-sections -fvisibility=hidden"
+            else
+                VARIANT_SUFFIX=""
+                G0_FLAG=""
+                DEST_SUFFIX=""
+                PIC_FLAG=""
+                EXTRA_FLAGS="-O3 -ffunction-sections -fdata-sections"
+            fi
+
+            log "--- runtimes: ${TRIPLE} ${CORE}${VARIANT_SUFFIX} ---"
+
+            BUILD_DIR="${RUNTIMES_BUILD_ROOT}/build-${BUILD_PREFIX}-${CORE}${VARIANT_SUFFIX}"
+            INSTALL_DIR="${RUNTIMES_INSTALL_ROOT}/${BUILD_PREFIX}-${CORE}${VARIANT_SUFFIX}"
+            mkdir -p "${BUILD_DIR}" "${INSTALL_DIR}"
+
+            # Combine base flags with extra flags
+            COMBINED_C_FLAGS="${G0_FLAG} -m${CORE} ${PIC_FLAG} ${EXTRA_FLAGS} ${EXTRA_C_FLAGS}"
+            COMBINED_CXX_FLAGS="${G0_FLAG} -m${CORE} ${PIC_FLAG} ${EXTRA_FLAGS} ${EXTRA_CXX_FLAGS}"
+
+            cmake -G Ninja \
+                -DCMAKE_C_COMPILER="${CLANG}" \
+                -DCMAKE_CXX_COMPILER="${CLANGXX}" \
+                -DCMAKE_C_COMPILER_TARGET="${TRIPLE}" \
+                -DCMAKE_CXX_COMPILER_TARGET="${TRIPLE}" \
+                -DCMAKE_C_FLAGS="${COMBINED_C_FLAGS}" \
+                -DCMAKE_CXX_FLAGS="${COMBINED_CXX_FLAGS}" \
+                -DLIBCXX_EXTRA_SITE_DEFINES="${EXTRA_SITE_DEFINES}" \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}" \
+                -DCMAKE_CROSSCOMPILING=ON \
+                -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY \
+                -DLLVM_ENABLE_RUNTIMES="libunwind;libcxxabi;libcxx" \
+                -DLIBUNWIND_ENABLE_SHARED=OFF \
+                -DLIBUNWIND_ENABLE_THREADS="${ENABLE_THREADS}" \
+                -DLIBUNWIND_USE_COMPILER_RT=ON \
+                -DLIBUNWIND_IS_BAREMETAL=ON \
+                -DLIBCXXABI_ENABLE_SHARED=OFF \
+                -DLIBCXXABI_ENABLE_THREADS="${ENABLE_THREADS}" \
+                -DLIBCXXABI_BAREMETAL=ON \
+                -DLIBCXXABI_USE_COMPILER_RT=ON \
+                -DLIBCXXABI_USE_LLVM_UNWINDER=ON \
+                -DLIBCXX_CXX_ABI=libcxxabi \
+                -DLIBCXX_ENABLE_SHARED=OFF \
+                -DLIBCXX_ENABLE_THREADS="${ENABLE_THREADS}" \
+                -DLIBCXX_HAS_PTHREAD_API="${ENABLE_THREADS}" \
+		-DLIBCXX_ENABLE_TIME_ZONE_DATABASE=OFF \
+                -DLIBCXX_ENABLE_EXCEPTIONS=ON \
+		-DLIBCXX_ENABLE_FILESYSTEM=${ENABLE_THREADS} \
+                -DLIBCXX_ENABLE_MONOTONIC_CLOCK="${MONOTONIC_CLOCK}" \
+                -DLIBCXX_ENABLE_RANDOM_DEVICE=OFF \
+                -DLIBCXX_ENABLE_RTTI=ON \
+                -DLIBCXX_ENABLE_WIDE_CHARACTERS="${WIDE_CHARACTERS}" \
+                -DLIBCXX_ENABLE_LOCALIZATION="${LOCALIZATION}" \
+                -DLIBCXX_USE_COMPILER_RT=ON \
+                -DRUNTIMES_USE_LIBC="${USE_LIBC}" \
+                -S "${RUNTIMES_SRC}" \
+                -B "${BUILD_DIR}"
+
+            cmake --build "${BUILD_DIR}" -j"${JOBS}" -- install
+
+            # Copy runtimes libs/headers into the final install tree
+            DEST_LIB="${DEST_BASE}/lib/${CORE}${DEST_SUFFIX}"
+            DEST_INC="${DEST_BASE}/include"
+            mkdir -p "${DEST_LIB}" "${DEST_INC}"
+
+            if [[ -d "${INSTALL_DIR}/lib" ]]; then
+                cp -rvf "${INSTALL_DIR}/lib/"* "${DEST_LIB}/"
+            fi
+            if [[ -d "${INSTALL_DIR}/include" ]]; then
+                cp -rvf "${INSTALL_DIR}/include/"* "${DEST_INC}/"
+            fi
+            log "Installed runtimes for ${TRIPLE} ${CORE}${VARIANT_SUFFIX} -> ${DEST_LIB}"
+        done
+    done
+
+    # ---------------------------------------------------------------------------
+    # Copy built libraries to all other architecture versions
+    # ---------------------------------------------------------------------------
+    log "=== Symlinking runtimes to all architecture versions for ${TRIPLE} ==="
+
+    # Determine the source core (first in BUILD_CORES)
+    SOURCE_CORE=$(echo ${BUILD_CORES} | awk '{print $1}')
+    log "Using ${SOURCE_CORE} as symlink target for other architectures"
+
+    for CORE in ${ALL_CORES}; do
+        # Skip if this core was already built
+        if echo "${BUILD_CORES}" | grep -qw "${CORE}"; then
+            log "Skipping ${CORE} (already built)"
+            continue
+        fi
+
+        log "Symlinking libraries for ${CORE} -> ${SOURCE_CORE}"
+
+        LIB_BASE="${DEST_BASE}/lib"
+
+        # Symlink individual files (not directories) so a downstream "cp -drfv"
+        # never tries to overwrite an existing real directory with a symlink.
+        # Flat layout: variant dirs are siblings under lib/, so the source is
+        # always one level up (../<source-core><suffix>).
+        for VARIANT_SUFFIX in "" "-G0" "-G0-pic"; do
+            SOURCE_VARIANT_DIR="${LIB_BASE}/${SOURCE_CORE}${VARIANT_SUFFIX}"
+            DEST_VARIANT_DIR="${LIB_BASE}/${CORE}${VARIANT_SUFFIX}"
+
+            if [[ ! -d "${SOURCE_VARIANT_DIR}" ]]; then
+                log "WARNING: Source directory ${SOURCE_VARIANT_DIR} not found, skipping"
+                continue
+            fi
+
+            mkdir -p "${DEST_VARIANT_DIR}"
+
+            REL_PREFIX="../${SOURCE_CORE}${VARIANT_SUFFIX}"
+
+            for SRC_FILE in "${SOURCE_VARIANT_DIR}"/*; do
+                [[ -f "${SRC_FILE}" ]] || continue
+                FNAME="$(basename "${SRC_FILE}")"
+                DEST_FILE="${DEST_VARIANT_DIR}/${FNAME}"
+                rm -f "${DEST_FILE}"
+                ln -s "${REL_PREFIX}/${FNAME}" "${DEST_FILE}"
+            done
+            log "Symlinked runtimes (${VARIANT_SUFFIX:-non-G0}): ${CORE} -> ${SOURCE_CORE}"
+        done
+    done
+
+    log "=== Build complete for ${TRIPLE} ==="
+    log "Install tree: ${DEST_BASE}/"
+}
+
+# ---------------------------------------------------------------------------
+# Pre-flight checks
+# ---------------------------------------------------------------------------
+log "=== Pre-flight checks ==="
+require_tool cmake
+require_tool "${NINJA}"
+
+[[ -x "${CLANG}" ]]   || die "hexagon-clang/clang not found (tried ${TOOLCHAIN}/bin/hexagon-clang and ${TOOLCHAIN}/bin/clang)"
+[[ -x "${CLANGXX}" ]] || die "hexagon-clang++/clang++ not found (tried ${TOOLCHAIN}/bin/hexagon-clang++ and ${TOOLCHAIN}/bin/clang++)"
+[[ -d "${RUNTIMES_SRC}" ]] || die "runtimes source not found at ${RUNTIMES_SRC}"
+
+# Show Hexagon target headers directory structure
+HEXAGON_TARGET_DIR="$(realpath "$(dirname "${CLANG}")/../target")"
+if [[ -d "${HEXAGON_TARGET_DIR}" ]]; then
+    log "=== Hexagon target headers directory structure ==="
+    find "${HEXAGON_TARGET_DIR}" -type f
+else
+    log "WARNING: Hexagon target directory not found at ${HEXAGON_TARGET_DIR}"
+fi
+
+mkdir -p "${RUNTIMES_BUILD_ROOT}" "${RUNTIMES_INSTALL_ROOT}"
+
+# ---------------------------------------------------------------------------
+# Triple configurations
+#
+# build_runtimes_for_triple \
+#     <triple>          <build-prefix> \
+#     <extra-c-flags>   <extra-cxx-flags> \
+#     <threads>         <use-libc> \
+#     <monotonic-clock> <wide-chars> <localization> \
+#     [extra-site-defines]
+# ---------------------------------------------------------------------------
+
+# 1. Baremetal: no threads, no localization, no wide chars.
+#    CXX flags carry -nostdlib++ -nostdinc++ to avoid pulling in host headers.
+build_runtimes_for_triple \
+    "hexagon-unknown-none-elf"      "hexagon" \
+    "--cstdlib=picolibc"            "--cstdlib=picolibc -nostdlib++ -nostdinc++" \
+    "OFF"                           "picolibc" \
+    "OFF"                           "OFF" "OFF" \
+    ""                              "${FINAL_INSTALL}/target/picolibc/hexagon-unknown-none-elf"
+
+# 2. H2 Linux: threads + localization + wide chars, picolibc defines required.
+#    These defines describe the picolibc platform's capabilities and are baked
+#    into the installed __config_site header so all downstream consumers see them.
+H2_SITE_DEFINES="_GNU_SOURCE=;_PICOLIBC_CTYPE_SMALL=0;_POSIX_TIMERS=1;_POSIX_THREADS"
+build_runtimes_for_triple \
+    "hexagon-unknown-h2-elf"        "hexagon-h2" \
+    "--cstdlib=picolibc"            "--cstdlib=picolibc -nostdlib++ -nostdinc++" \
+    "ON"                            "picolibc" \
+    "ON"                            "ON" "ON" \
+    "${H2_SITE_DEFINES}"            "${FINAL_INSTALL}/target/picolibc/hexagon-unknown-h2-elf"
+
+# ---------------------------------------------------------------------------
+# Done
+# ---------------------------------------------------------------------------
+log "=== All builds complete ==="


### PR DESCRIPTION
These build the Hexagon picolibc sysroot on top of an existing toolchain, in order:

  1. build_hexagon_builtins.sh  - compiler-rt builtins (G0/non-G0/PIC)
  2. build_hexagon_picolibc.sh  - picolibc for all cores/variants
  3. build_hexagon_h2.sh        - H2 libraries (bases 68/73/81)
  4. build_hexagon_runtimes.sh  - libunwind, libc++abi, libc++

Each script installs into
Tools/target/picolibc/hexagon-unknown-{none,h2,qurt}-elf, building one core per arch group and symlinking/copying to the full core set.

Add .github/workflows/build-sysroot.yml (manual trigger) with three jobs:

  - build-toolchain: builds clang + ELD (no lld) from latest llvm-project and eld, using the repo's cmake caches.
  - build-qemu: builds qemu-system-hexagon from qualcomm/qemu (hexagon-softmmu only), needed by the H2 build to run the asm_offsets generator ELF.
  - build-sysroot: downloads the toolchain and qemu, fetches latest llvm-project, picolibc, and H2, runs the four scripts in order, and uploads the sysroot as a tarball artifact.